### PR TITLE
Creates CassandraBlock interface which decorates the Block interface …

### DIFF
--- a/cassandra-scheduler/src/dist/conf/scheduler.yml
+++ b/cassandra-scheduler/src/dist/conf/scheduler.yml
@@ -23,6 +23,7 @@ cassandra:
     newMb : ${CASSANDRA_HEAP_MB:-100}
   jmxPort: ${CASSANDRA_JMX_PORT:-7199}
   numTokens : ${CASSANDRA_NUM_TOKENS:-256}
+  volumeSizeMb : ${CASSANDRA_VOLUME_SIZE_MB:-9216}
   hintedHandoffEnabled : ${CASSANDRA_HINTED_HANDOFF_ENABLED:-true}
   maxHintWindowInMs : ${CASSANDRA_MAX_HINT_WINDOW_IN_MS:-10800000}
   hintedHandoffThrottleInKb : ${CASSANDRA_HINTED_HANDOFF_THROTTLE_IN_KB:-1024}

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/CassandraRepairScheduler.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/CassandraRepairScheduler.java
@@ -65,7 +65,7 @@ public class CassandraRepairScheduler {
         final List<CassandraTask> terminatedCassandraTasks = cassandraTasks.getTerminatedTasks();
         terminatedCassandraTasks.stream()
                 .filter(task -> (block == null) ? true :
-                        task.getId() != block.getTaskId())
+                        task.getId().equals(block.getTaskId()))
                 .forEach(cassandraTask -> terminatedTasks.add(
                                 cassandraTask.toProto()));
         return terminatedTasks;

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/CassandraScheduler.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/CassandraScheduler.java
@@ -9,6 +9,7 @@ import com.mesosphere.dcos.cassandra.scheduler.offer.LogOperationRecorder;
 import com.mesosphere.dcos.cassandra.scheduler.offer.PersistentOfferRequirementProvider;
 import com.mesosphere.dcos.cassandra.scheduler.offer.PersistentOperationRecorder;
 import com.mesosphere.dcos.cassandra.scheduler.persistence.PersistenceException;
+import com.mesosphere.dcos.cassandra.scheduler.plan.CassandraBlock;
 import com.mesosphere.dcos.cassandra.scheduler.plan.CassandraPlan;
 import com.mesosphere.dcos.cassandra.scheduler.plan.PlanFactory;
 import com.mesosphere.dcos.cassandra.scheduler.tasks.CassandraTasks;
@@ -126,13 +127,16 @@ public class CassandraScheduler implements Scheduler, Managed {
 
             List<Protos.OfferID> acceptedOffers = new ArrayList<>();
             final Block currentBlock = planManager.getCurrentBlock();
+
             acceptedOffers.addAll(
                     planScheduler.resourceOffers(driver, offers, currentBlock));
             List<Protos.Offer> unacceptedOffers = filterAcceptedOffers(offers,
                     acceptedOffers);
             acceptedOffers.addAll(
-                    repairScheduler.resourceOffers(driver, unacceptedOffers,
-                            currentBlock));
+                    repairScheduler.resourceOffers(
+                            driver,
+                            unacceptedOffers,
+                            (CassandraBlock)currentBlock));
 
             declineOffers(driver, acceptedOffers, offers);
         }

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/CassandraConfigParser.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/CassandraConfigParser.java
@@ -34,8 +34,8 @@ public class CassandraConfigParser {
     private int batchlogReplayThrottleInKb;
     @JsonProperty("partitioner")
     private String partitioner;
-    @JsonProperty("persistentVolumeSize")
-    private int persistentVolumeSizeMb;
+    @JsonProperty("volumeSizeMb")
+    private int volumeSizeMb;
     @JsonProperty("diskFailurePolicy")
     private String diskFailurePolicy;
     @JsonProperty("commitFailurePolicy")
@@ -159,7 +159,7 @@ public class CassandraConfigParser {
         maxHintsDeliveryThreads = DEFAULT_MAX_HINTS_DELIVERY_THREADS;
         batchlogReplayThrottleInKb = DEFAULT_BATCHLOG_REPLAY_THROTTLE_IN_KB;
         partitioner = DEFAULT_PARTITIONER;
-        persistentVolumeSizeMb = CassandraConfig.DEFAULT.getVolume().getSizeMb();
+        volumeSizeMb = CassandraConfig.DEFAULT.getVolume().getSizeMb();
         diskFailurePolicy = DEFAULT_DISK_FAILURE_POLICY;
         commitFailurePolicy = DEFAULT_COMMIT_FAILURE_POLICY;
         keyCacheSizeInMb = DEFAULT_KEY_CACHE_SIZE_IN_MB;
@@ -643,12 +643,12 @@ public class CassandraConfigParser {
         this.partitioner = partitioner;
     }
 
-    public int getPersistentVolumeSizeMb() {
-        return persistentVolumeSizeMb;
+    public int getVolumeSizeMb() {
+        return volumeSizeMb;
     }
 
-    public void setPersistentVolumeSizeMb(int persistentVolumeSizeMb) {
-        this.persistentVolumeSizeMb = persistentVolumeSizeMb;
+    public void setVolumeSizeMb(int persistentVolumeSizeMb) {
+        this.volumeSizeMb = volumeSizeMb;
     }
 
     public int getRangeRequestTimeoutInMs() {

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraBlock.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraBlock.java
@@ -1,0 +1,8 @@
+package com.mesosphere.dcos.cassandra.scheduler.plan;
+
+
+import org.apache.mesos.scheduler.plan.Block;
+
+public interface CassandraBlock extends Block {
+    String getTaskId();
+}

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonBlock.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonBlock.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
-public class CassandraDaemonBlock implements Block {
+public class CassandraDaemonBlock implements CassandraBlock {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(
             CassandraDaemonBlock.class);
@@ -124,7 +124,7 @@ public class CassandraDaemonBlock implements Block {
                         taskId,
                         id);
             } else {
-                //update the stat
+                //update the status
                 cassandraTasks.update(status);
                 CassandraDaemonTask task = cassandraTasks.getDaemons().get(
                         taskId);
@@ -184,4 +184,8 @@ public class CassandraDaemonBlock implements Block {
                 + oldStatus + " to: " + status);
     }
 
+    @Override
+    public String getTaskId() {
+        return taskId;
+    }
 }

--- a/cassandra-scheduler/src/test/resources/scheduler.yml
+++ b/cassandra-scheduler/src/test/resources/scheduler.yml
@@ -22,6 +22,7 @@ cassandra:
     sizeMb : ${CASSANDRA_HEAP_MB:-2048}
     newMb : ${CASSANDRA_HEAP_MB:-100}
   jmxPort: ${CASSANDRA_JMX_PORT:-7199}
+  volumeSizeMb : ${CASSANDRA_VOLUME_SIZE_MB :- 9216}
   numTokens : ${CASSANDRA_NUM_TOKENS:-256}
   hintedHandoffEnabled : ${CASSANDRA_HINTED_HANDOFF_ENABLED:-true}
   maxHintWindowInMs : ${CASSANDRA_MAX_HINT_WINDOW_IN_MS:-10800000}


### PR DESCRIPTION
…with getTaskId(). This method allows the RecoveryScheduler to not act on the currently executing Block. This will be nessecary for config update as part of the Plan execution will involve calling shutdown on the CassandraDaemon process and waiting for the task to die.

Updates the ConfigurationParser to correctly accept and generate different volume sizes for the Cassandra instances.

Scale up now works as exepceted as does recovery during node failure.
