### PR TITLE
Modifies the httpclient threadpool to use a simple cachedThreadPool f…

### DIFF
--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/CassandraExecutor.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/CassandraExecutor.java
@@ -19,21 +19,16 @@ public class CassandraExecutor implements Executor {
             CassandraExecutor.class
     );
 
-    public static CassandraExecutor create() {
-        return new CassandraExecutor();
-    }
-
-    @Inject
-    public CassandraExecutor() {
-
-    }
 
     private ExecutorDriver driver;
-
     private volatile CassandraDaemonProcess cassandra;
+    private final ScheduledExecutorService executor;
 
-    private final ScheduledExecutorService executor =
-            Executors.newScheduledThreadPool(10);
+    @Inject
+    public CassandraExecutor(final ScheduledExecutorService executor) {
+        this.executor = executor;
+    }
+
 
     @Override
     public void registered(ExecutorDriver driver,

--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/ExecutorDriverDispatcher.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/ExecutorDriverDispatcher.java
@@ -1,0 +1,56 @@
+package com.mesosphere.dcos.cassandra.executor;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.dropwizard.lifecycle.Managed;
+import org.apache.mesos.Executor;
+import org.apache.mesos.ExecutorDriver;
+import org.apache.mesos.Protos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ExecutorService;
+
+public class ExecutorDriverDispatcher implements Runnable, Managed{
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(ExecutorDriverDispatcher.class);
+
+    private static final int exitCode(final Protos.Status status){
+        return (status == Protos.Status.DRIVER_ABORTED ||
+                status == Protos.Status.DRIVER_NOT_STARTED) ?
+                -1 : 0;
+    }
+
+    private final ExecutorDriver driver;
+    private final ExecutorService executor;
+
+    @Inject
+    public ExecutorDriverDispatcher(final ExecutorDriverFactory driverFactory,
+                                    final Executor executor,
+                                    final ExecutorService executorService) {
+        this.driver = driverFactory.getDriver(executor);
+        this.executor = executorService;
+    }
+
+    @Override
+    public void run() {
+
+        LOGGER.info("Starting driver execution");
+        Protos.Status status = driver.run();
+        LOGGER.info("Driver execution complete status = {}",status);
+        driver.stop();
+        System.exit(exitCode(status));
+    }
+
+    @Override
+    public void start() throws Exception {
+        LOGGER.info("Starting ExecutorDriver");
+        executor.submit(this);
+    }
+
+    @Override
+    public void stop() throws Exception {
+        LOGGER.info("Stopping ExecutorDriver");
+        this.driver.stop();
+    }
+}

--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/ExecutorDriverFactory.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/ExecutorDriverFactory.java
@@ -1,0 +1,12 @@
+package com.mesosphere.dcos.cassandra.executor;
+
+import org.apache.mesos.Executor;
+import org.apache.mesos.ExecutorDriver;
+
+/**
+ * Created by kowens on 2/17/16.
+ */
+public interface ExecutorDriverFactory {
+
+    ExecutorDriver getDriver(Executor executor);
+}

--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/ExecutorModule.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/ExecutorModule.java
@@ -2,6 +2,13 @@ package com.mesosphere.dcos.cassandra.executor;
 
 import com.google.inject.AbstractModule;
 import com.mesosphere.dcos.cassandra.executor.config.CassandraExecutorConfiguration;
+import org.apache.mesos.Executor;
+import org.apache.mesos.ExecutorDriver;
+import org.apache.mesos.MesosExecutorDriver;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Created by kowens on 2/10/16.
@@ -16,16 +23,21 @@ public class ExecutorModule extends AbstractModule {
     }
 
     public ExecutorModule(final CassandraExecutorConfiguration configuration) {
-
         this.configuration = configuration;
-
     }
 
 
     @Override
     protected void configure() {
 
-        bind(CassandraExecutor.class).asEagerSingleton();
+        bind(ExecutorService.class).toInstance(
+                Executors.newCachedThreadPool());
+        bind(ScheduledExecutorService.class).toInstance(
+                Executors.newScheduledThreadPool(10));
+        bind(Executor.class).to(CassandraExecutor.class).asEagerSingleton();
+        bind(ExecutorDriverFactory.class)
+                .to(MesosExecutorDriverFactory.class)
+                .asEagerSingleton();
 
     }
 }

--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/Main.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/Main.java
@@ -55,39 +55,17 @@ public class Main extends Application<CassandraExecutorConfiguration> {
 
         Injector injector = Guice.createInjector(baseModule);
 
-
         environment.healthChecks().register(DaemonRunning.NAME,
                 injector.getInstance(DaemonRunning.class));
-
         environment.healthChecks().register(DaemonMode.NAME,
                 injector.getInstance(DaemonMode.class));
-
         environment.jersey().register(
                 injector.getInstance(CassandraDaemonController.class));
 
-        final MesosExecutorDriver driver = new MesosExecutorDriver(
-                injector.getInstance(CassandraExecutor.class));
+        environment.lifecycle().manage(
+                injector.getInstance(ExecutorDriverDispatcher.class));
 
-        final int status;
 
-        switch (driver.run()) {
-            case DRIVER_STOPPED:
-                status = 0;
-                break;
-            case DRIVER_ABORTED:
-                status = 1;
-                break;
-            case DRIVER_NOT_STARTED:
-                status = 2;
-                break;
-            default:
-                status = 3;
-                break;
-        }
-
-        driver.stop();
-
-        System.exit(status);
 
 
     }

--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/MesosExecutorDriverFactory.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/MesosExecutorDriverFactory.java
@@ -1,0 +1,16 @@
+package com.mesosphere.dcos.cassandra.executor;
+
+import org.apache.mesos.Executor;
+import org.apache.mesos.ExecutorDriver;
+import org.apache.mesos.MesosExecutorDriver;
+
+/**
+ * Created by kowens on 2/17/16.
+ */
+public class MesosExecutorDriverFactory implements ExecutorDriverFactory{
+
+    @Override
+    public ExecutorDriver getDriver(Executor executor) {
+        return new MesosExecutorDriver(executor);
+    }
+}

--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/resources/CassandraDaemonController.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/resources/CassandraDaemonController.java
@@ -6,6 +6,9 @@ import com.mesosphere.dcos.cassandra.common.config.CassandraConfig;
 import com.mesosphere.dcos.cassandra.common.tasks.CassandraStatus;
 import com.mesosphere.dcos.cassandra.executor.CassandraDaemonProcess;
 import com.mesosphere.dcos.cassandra.executor.CassandraExecutor;
+import org.apache.mesos.Executor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -14,6 +17,9 @@ import java.util.Optional;
 @Path("/v1/cassandra")
 @Produces(MediaType.APPLICATION_JSON)
 public class CassandraDaemonController {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(CassandraDaemonController.class);
 
     private final CassandraExecutor executor;
 
@@ -28,10 +34,13 @@ public class CassandraDaemonController {
     }
 
     @Inject
-    public CassandraDaemonController(CassandraExecutor executor) {
+    public CassandraDaemonController(Executor executor) {
 
-        this.executor = executor;
+        LOGGER.info("Setting executor to {}",executor);
 
+        this.executor = (CassandraExecutor) executor;
+
+        LOGGER.info("Set executor to {}",this.executor);
     }
 
     @GET

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/SchedulerModule.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/SchedulerModule.java
@@ -20,6 +20,8 @@ import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.Executors;
+
 public class SchedulerModule extends AbstractModule {
     private final static Logger LOGGER = LoggerFactory.getLogger(
             SchedulerModule.class);
@@ -29,9 +31,9 @@ public class SchedulerModule extends AbstractModule {
 
     public SchedulerModule(
             final CassandraSchedulerConfiguration configuration,
-            final Environment enviornment) {
+            final Environment environment) {
         this.configuration = configuration;
-        this.environment = enviornment;
+        this.environment = environment;
     }
 
     @Override
@@ -96,8 +98,7 @@ public class SchedulerModule extends AbstractModule {
                 new HttpClientBuilder(environment).using(
                         configuration.getHttpClientConfiguration())
                         .build("example-http-client"),
-                environment.lifecycle().executorService("client").maxThreads
-                        (100).minThreads(5).build()
+                Executors.newCachedThreadPool()
         ));
         bind(IdentityManager.class).asEagerSingleton();
         bind(ConfigurationManager.class).asEagerSingleton();


### PR DESCRIPTION
…rom Executors. Removes the construction via builder for simplicity.

Launches ExecutorDriver in a separate managed object. Running it inside of main was causing the main thread to block and not load the API resources.
Implements a bunch of shennanigans (Factory Pattern for ExecutorDriver creation) to get Guice to work correctly on non-injected objects.
The Executor APIs now work remotely ... but there is an issue with the ExecutorClient wrt to the path in the invoked URI.
