### PR TITLE
fixed a bug a IdentityError: swap the order of 'configured' and 'pers…

### DIFF
--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/IdentityManager.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/IdentityManager.java
@@ -30,7 +30,7 @@ public class IdentityManager implements Managed {
                 "The framework property %s has been modified " +
                         "from %s to %s. This changes is not allowed as it " +
                         "changes the identity of the framework.",
-                property, configured, persisted);
+                property, persisted, configured);
     }
 
     private void validate(Identity configured, Identity persisted) {


### PR DESCRIPTION
fixed a bug in IdentityManager class.  The order of two strings in IdentityError() are wrongly swapped, the fix is to switch them back.
