### PR TITLE
Handles cassandra binary version upgrade for minor releases. Kill's e…

### DIFF
--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/CassandraDaemonProcess.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/CassandraDaemonProcess.java
@@ -102,7 +102,8 @@ public class CassandraDaemonProcess {
                     LOGGER.info("Sent status update = {}", status);
                     open.set(false);
                     closeFuture.complete(CLOSED);
-                    return;
+                    System.exit(0);
+
 
                 } catch (InterruptedException ex) {
 

--- a/cassandra-scheduler/src/dist/conf/scheduler.yml
+++ b/cassandra-scheduler/src/dist/conf/scheduler.yml
@@ -17,7 +17,7 @@ cassandra:
   cpus: ${CASSANDRA_CPUS:-0.5}
   memoryMb: ${CASSANDRA_MEMORY_MB:-4096}
   diskMb: ${CASSANRA_DISK_MB:-10240}
-  version: 2.2.5
+  version: ${CASSANDRA_VERSION:-2.2.5}
   heap:
     sizeMb : ${CASSANDRA_HEAP_MB:-2048}
     newMb : ${CASSANDRA_HEAP_MB:-100}
@@ -108,3 +108,4 @@ identity:
   failoverTimeoutS : ${FRAMEWORK_FAILOVER_TIMEOUT_S:-604800}
   checkpoint : ${FRAMEWORK_CHECKPOINT:-true}
 seedsUrl: "http://${FRAMEWORK_NAME:-cassandra}.marathon.mesos:${API_PORT:-8080}/v1/seeds"
+phaseStrategy: ${PHASE_STRATEGY:-"org.apache.mesos.scheduler.plan.DefaultInstallStrategy"}

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/SchedulerModule.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/SchedulerModule.java
@@ -14,6 +14,7 @@ import com.mesosphere.dcos.cassandra.scheduler.config.*;
 import com.mesosphere.dcos.cassandra.scheduler.offer.PersistentOfferRequirementProvider;
 import com.mesosphere.dcos.cassandra.scheduler.persistence.PersistenceFactory;
 import com.mesosphere.dcos.cassandra.scheduler.persistence.ZooKeeperPersistence;
+import com.mesosphere.dcos.cassandra.scheduler.plan.CassandraPhaseStrategies;
 import com.mesosphere.dcos.cassandra.scheduler.plan.CassandraPlanManager;
 import com.mesosphere.dcos.cassandra.scheduler.tasks.CassandraReconciler;
 import com.mesosphere.dcos.cassandra.scheduler.tasks.CassandraTasks;
@@ -97,8 +98,12 @@ public class SchedulerModule extends AbstractModule {
         bindConstant().annotatedWith(
                 Names.named("ConfiguredPlanStrategy")).to(
                 configuration.getPlanStrategy());
-        bind(CassandraPlanManager.class).toInstance(CassandraPlanManager
-                .create());
+        bindConstant().annotatedWith(
+                Names.named("ConfiguredPhaseStrategy")).to(
+                configuration.getPhaseStrategy()
+        );
+        bind(CassandraPhaseStrategies.class).asEagerSingleton();
+        bind(CassandraPlanManager.class).asEagerSingleton();
         bind(ExecutorClient.class).toInstance(ExecutorClient.create(
                 new HttpClientBuilder(environment).using(
                         configuration.getHttpClientConfiguration())

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/CassandraSchedulerConfiguration.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/CassandraSchedulerConfiguration.java
@@ -26,6 +26,7 @@ public class CassandraSchedulerConfiguration extends Configuration {
     private CassandraConfigParser cassandraConfig;
     private int apiPort;
     private Identity identity;
+    private String phaseStrategy;
     private MesosConfig mesosConfig =
             MesosConfig.create(
                     "master.mesos:2181",
@@ -106,7 +107,7 @@ public class CassandraSchedulerConfiguration extends Configuration {
     @JsonProperty("cassandra")
     public CassandraSchedulerConfiguration setCassandraConfigParser
             (CassandraConfigParser
-                                                           cassandraConfig) {
+                     cassandraConfig) {
         this.cassandraConfig = cassandraConfig;
         return this;
     }
@@ -190,7 +191,9 @@ public class CassandraSchedulerConfiguration extends Configuration {
     }
 
     @JsonProperty("seedsUrl")
-    public String getSeedsUrl() { return seedsUrl; }
+    public String getSeedsUrl() {
+        return seedsUrl;
+    }
 
     @JsonProperty("seedsUrl")
     public CassandraSchedulerConfiguration setSeedsUrl(String seedsUrl) {
@@ -199,7 +202,9 @@ public class CassandraSchedulerConfiguration extends Configuration {
     }
 
     @JsonProperty("identity")
-    public Identity getIdentity() { return identity; }
+    public Identity getIdentity() {
+        return identity;
+    }
 
     @JsonProperty("identity")
     public CassandraSchedulerConfiguration setIdentity(Identity identity) {
@@ -207,10 +212,22 @@ public class CassandraSchedulerConfiguration extends Configuration {
         return this;
     }
 
+    @JsonProperty("phaseStrategy")
+    public String getPhaseStrategy() {
+        return phaseStrategy;
+    }
+
+    @JsonProperty("phaseStrategy")
+    public CassandraSchedulerConfiguration setPhaseStrategy(
+            String phaseStrategy) {
+        this.phaseStrategy = phaseStrategy;
+        return this;
+    }
 
     @JsonIgnore
-    public CassandraConfig getCassandraConfig(){
-
-        return cassandraConfig.getCassandraConfig(name,getSeedsUrl());
+    public CassandraConfig getCassandraConfig() {
+        return cassandraConfig.getCassandraConfig(name, getSeedsUrl());
     }
+
+
 }

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/ConfigurationManager.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/ConfigurationManager.java
@@ -190,6 +190,17 @@ public class ConfigurationManager implements Managed {
         }
     }
 
+    public CassandraTaskExecutor updateExecutor(
+            CassandraTask task,
+            String newId) {
+
+        return hasCurrentExecutorConfig(task.getExecutor()) ?
+                task.getExecutor() :
+                createExecutor(task.getExecutor().getFrameworkId(),
+                        newId + "_executor");
+
+    }
+
     public CassandraTaskExecutor createExecutor(String frameworkId,
                                                 String id) {
 
@@ -254,52 +265,56 @@ public class ConfigurationManager implements Managed {
         );
     }
 
-    public CassandraDaemonTask replaceDaemon(CassandraDaemonTask task){
+    public CassandraDaemonTask replaceDaemon(CassandraDaemonTask task) {
         String id = task.getName() + "_" + UUID.randomUUID().toString();
         return task.mutable()
                 .setId(id)
                 .setStatus(
-                CassandraDaemonStatus.create(Protos.TaskState.TASK_STAGING,
-                id,
-                task.getSlaveId(),
-                task.getName(),
-                Optional.empty(),
-                CassandraMode.STARTING)).build();
+                        CassandraDaemonStatus.create(
+                                Protos.TaskState.TASK_STAGING,
+                                id,
+                                task.getSlaveId(),
+                                task.getName(),
+                                Optional.empty(),
+                                CassandraMode.STARTING)).build();
 
     }
 
-    public boolean hasCurrentConfig(final CassandraDaemonTask task){
-
-        return task.getExecutor().getCommand().equals(executorConfig
+    public boolean hasCurrentExecutorConfig(
+            final CassandraTaskExecutor executor) {
+       return executor.getCommand().equals(executorConfig
                 .getCommand()) &&
-                Double.compare(task.getExecutor().getCpus(),
-                executorConfig.getCpus()) == 0 &&
-                task.getExecutor().getDiskMb() ==
+                Double.compare(executor.getCpus(),
+                        executorConfig.getCpus()) == 0 &&
+               executor.getDiskMb() ==
                         executorConfig.getDiskMb() &&
-                task.getExecutor().getMemoryMb() ==
+               executor.getMemoryMb() ==
                         executorConfig.getMemoryMb() &&
-                task.getExecutor().getUriStrings().containsAll(
-                       Arrays.asList(
-                               executorConfig.getCassandraLocationString(),
-                               executorConfig.getExecutorLocationString(),
-                               executorConfig.getJreLocationString()
-                       )
+               executor.getUriStrings().containsAll(
+                        Arrays.asList(
+                                executorConfig.getCassandraLocationString(),
+                                executorConfig.getExecutorLocationString(),
+                                executorConfig.getJreLocationString()
+                        )
                 ) &&
-                task.getExecutor().getHeapMb() == executorConfig.getHeapMb() &&
+               executor.getHeapMb() == executorConfig.getHeapMb();
+    }
+
+    public boolean hasCurrentConfig(final CassandraDaemonTask task) {
+
+        return  hasCurrentExecutorConfig(task.getExecutor()) &&
                 task.getConfig().equals(cassandraConfig);
 
     }
 
-    public CassandraDaemonTask updateConfig(final CassandraDaemonTask task){
+    public CassandraDaemonTask updateConfig(final CassandraDaemonTask task) {
 
         String id = task.getName() + "_" + UUID.randomUUID().toString();
         return CassandraDaemonTask.create(
                 id,
                 task.getSlaveId(),
                 task.getHostname(),
-                createExecutor(
-                        task.getExecutor().getFrameworkId(),
-                        task.getExecutor().getId()),
+                updateExecutor(task,id),
                 task.getName(),
                 task.getRole(),
                 task.getPrincipal(),
@@ -323,7 +338,7 @@ public class ConfigurationManager implements Managed {
                         CassandraMode.STARTING));
     }
 
-    public CassandraTask updateId(CassandraTask task){
+    public CassandraTask updateId(CassandraTask task) {
         return task.updateId(
                 task.getName() + "_" + UUID.randomUUID().toString());
     }

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraPhaseStrategies.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraPhaseStrategies.java
@@ -1,5 +1,7 @@
 package com.mesosphere.dcos.cassandra.scheduler.plan;
 
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import org.apache.mesos.scheduler.plan.DefaultInstallStrategy;
 import org.apache.mesos.scheduler.plan.Phase;
 import org.apache.mesos.scheduler.plan.PhaseStrategy;
@@ -9,16 +11,34 @@ import org.apache.mesos.scheduler.plan.PhaseStrategy;
  */
 public class CassandraPhaseStrategies {
 
-    private CassandraPhaseStrategies() {
+    private final Class<?> phaseStrategy;
+    @Inject
+    public CassandraPhaseStrategies(
+            @Named("ConfiguredPhaseStrategy")String phaseStrategy) {
+        try {
+            this.phaseStrategy =
+                    this.getClass().getClassLoader().loadClass(phaseStrategy);
+        } catch (ClassNotFoundException e) {
+           throw new RuntimeException(String.format(
+                   "Failed to load class for phaseStrategy $s",
+                   phaseStrategy
+           ),e);
+        }
     };
 
-    public static PhaseStrategy get(Phase phase) {
+    public PhaseStrategy get(Phase phase) {
         if (phase instanceof EmptyPlan.EmptyPhase) {
             return EmptyPlan.EmptyStrategy.get();
         } else if (phase instanceof ReconciliationPhase) {
             return ReconciliationStrategy.create((ReconciliationPhase) phase);
         } else {
-            return new DefaultInstallStrategy(phase);
+            try {
+                return (PhaseStrategy)
+                        phaseStrategy.getConstructor(Phase.class).newInstance(
+                        phase);
+            } catch (Exception ex){
+                throw new RuntimeException("Failed to PhaseStrategy",ex);
+            }
         }
     }
 }


### PR DESCRIPTION
…xecutor on exit of Cassandra Daemon to ensure that duplicate executors are not spawned creating a port conflict. Renames executor when executor configuration changes for Cassandra (e.g. Cassandra binary version).
