### PR TITLE
Pass correct path for metrics conf generation

### DIFF
--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/CassandraDaemonProcess.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/CassandraDaemonProcess.java
@@ -248,8 +248,7 @@ public class CassandraDaemonProcess {
                 .build().writeDaemonConfiguration(paths.cassandraConfig());
 
         if (metricsEnabled) {
-            metricsEnabled = MetricsConfig.writeMetricsConfig(
-                    paths.cassandraConfig());
+            metricsEnabled = MetricsConfig.writeMetricsConfig(paths.conf());
         }
 
         process = createDaemon();


### PR DESCRIPTION
Fix for:

 com.mesosphere.dcos.cassandra.executor.metrics.MetricsConfig: Failed to write configuration
! java.io.FileNotFoundException: apache-cassandra-2.2.5/conf/cassandra.yaml/metrics-reporter-config.yaml (Not a directory)
