### PR TITLE
Update cassandra packager to perform conf/ changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ generated/
 
 cassandra-executor/apache-cassandra-2.2.5/
 cassandra-executor/volume/
+cassandra-bin-tmp/

--- a/build-cassandra-bin.bash
+++ b/build-cassandra-bin.bash
@@ -22,6 +22,7 @@ REPORTER_CONFIG_VERSION_IN="3.0.1-SNAPSHOT"
 REPORTER_CONFIG_SHA1="595b3c239e2c4764c66d214837005a8e0fe01d99"
 REPORTER_CONFIG_VERSION_OUT="3.0.1-${REPORTER_CONFIG_SHA1:0:8}" # get first 8 chars of sha
 SEED_PROVIDER_VERSION="0.1.0"
+READYTALK_MVN_REPO_DOWNLOAD_URL="https://dl.bintray.com/readytalk/maven/com/readytalk"
 
 # PATHS AND FILENAME SETTINGS
 CASSANDRA_DIST_NAME="apache-cassandra-${CASSANDRA_VERSION}"
@@ -29,10 +30,16 @@ CASSANDRA_STOCK_IMAGE="${CASSANDRA_DIST_NAME}-bin.tar.gz"
 CASSANDRA_CUSTOM_IMAGE="${CASSANDRA_DIST_NAME}-bin-dcos.tar.gz"
 CASSANDRA_STOCK_IMAGE_DOWNLOAD_URL="https://archive.apache.org/dist/cassandra/${CASSANDRA_VERSION}/${CASSANDRA_STOCK_IMAGE}"
 
+function _sha1sum {
+    # Try 'sha1sum' (Linux) with fallback to 'shasum' (OSX)
+    SHA1SUM_EXE=$(which sha1suma || which shasum)
+    $SHA1SUM_EXE $@
+}
+
 function _download {
     if [ ! -f "$2" ]; then
         wget --progress=dot -e dotbytes=1M -O $2 $1
-        sha1sum $2
+        _sha1sum $2
     fi
 }
 
@@ -53,11 +60,13 @@ function _package_github {
 mkdir -p "cassandra-bin-tmp"
 cd "cassandra-bin-tmp"
 
-# Download and unpack stock cassandra-bin and verify with sha1 file
+###
+# Download and unpack stock cassandra-bin and verify with downloaded sha1 file
+###
 
 _download $CASSANDRA_STOCK_IMAGE_DOWNLOAD_URL.sha1 "${CASSANDRA_STOCK_IMAGE}.sha1"
 _download $CASSANDRA_STOCK_IMAGE_DOWNLOAD_URL "${CASSANDRA_STOCK_IMAGE}"
-if [ "$(sha1sum $CASSANDRA_STOCK_IMAGE | awk '{print $1}')" != "$(cat ${CASSANDRA_STOCK_IMAGE}.sha1)" ]; then
+if [ "$(_sha1sum $CASSANDRA_STOCK_IMAGE | awk '{print $1}')" != "$(cat ${CASSANDRA_STOCK_IMAGE}.sha1)" ]; then
     echo "SHA1 MISMATCH: ${CASSANDRA_STOCK_IMAGE}"
     exit 1
 else
@@ -66,42 +75,66 @@ fi
 rm -rf $CASSANDRA_DIST_NAME
 tar xzf $CASSANDRA_STOCK_IMAGE
 
+###
+# Modify stock cassandra config
+###
+
+CONF_DIR="${CASSANDRA_DIST_NAME}/conf"
+_sha1sum "${CONF_DIR}"/* &> confdir-before.txt || true
+
+# Remove default cassandra-rackdc.properties and cassandra-topology.properties.
+# The framework will provide this configuration on-the-fly.
+
+echo "##### Remove cassandra-[rackdc|topology].properties #####"
+
+rm -v "${CONF_DIR}"/cassandra-rackdc.properties
+rm -v "${CONF_DIR}"/cassandra-topology.properties
+
+# Make a copy of cassandra-env.sh named cassandra-env.sh.bak, then comment out any JMX_PORT
+# configuration. This value is customized by the framework.
+
+echo "##### Disable JMX_PORT in cassandra-env.sh #####"
+
+# "JMX_PORT=???" => "#DISABLED FOR DC/OS\n#JMX_PORT=???"
+sed -i "s/\(^JMX_PORT=.*\)/#DISABLED FOR DC\/OS:\n#\1/g" "${CONF_DIR}"/cassandra-env.sh
+
+_sha1sum "${CONF_DIR}"/* &> confdir-after.txt || true
+
+###
+# Copy seed provider and statsd libraries into cassandra-bin's lib dir
+###
+
 LIB_DIR="${CASSANDRA_DIST_NAME}/lib"
+_sha1sum "${LIB_DIR}"/*.jar &> libdir-before.txt || true
 
-sha1sum "${LIB_DIR}"/*.jar &> libdir-before.txt || true
-
-# Copy libraries into cassandra-bin's lib dir
-
-echo "##### Seed Provider #####"
+echo "##### Install custom seed provider #####"
 
 # Copy seedprovider lib from regular local build into cassandra-bin/lib
 cp -v ../seedprovider/build/libs/seedprovider-${SEED_PROVIDER_VERSION}.jar ${LIB_DIR}
 
-echo "##### StatsD Metrics #####"
+echo "##### Install StatsD metrics support #####"
 
-# StatsD Reporter: add stock libs from maven repo
-_download "https://dl.bintray.com/readytalk/maven/com/readytalk/metrics${METRICS_INTERFACE_VERSION}-statsd/${STATSD_REPORTER_VERSION}/metrics${METRICS_INTERFACE_VERSION}-statsd-${STATSD_REPORTER_VERSION}.jar" "metrics${METRICS_INTERFACE_VERSION}-statsd-${STATSD_REPORTER_VERSION}.jar"
+# StatsD Reporter: add stock libraries from maven repo
+_download "${READYTALK_MVN_REPO_DOWNLOAD_URL}/metrics${METRICS_INTERFACE_VERSION}-statsd/${STATSD_REPORTER_VERSION}/metrics${METRICS_INTERFACE_VERSION}-statsd-${STATSD_REPORTER_VERSION}.jar" "metrics${METRICS_INTERFACE_VERSION}-statsd-${STATSD_REPORTER_VERSION}.jar"
 cp -v "metrics${METRICS_INTERFACE_VERSION}-statsd-${STATSD_REPORTER_VERSION}.jar" ${LIB_DIR}
-_download "https://dl.bintray.com/readytalk/maven/com/readytalk/metrics-statsd-common/${STATSD_REPORTER_VERSION}/metrics-statsd-common-${STATSD_REPORTER_VERSION}.jar" "metrics-statsd-common-${STATSD_REPORTER_VERSION}.jar"
+_download "${READYTALK_MVN_REPO_DOWNLOAD_URL}/metrics-statsd-common/${STATSD_REPORTER_VERSION}/metrics-statsd-common-${STATSD_REPORTER_VERSION}.jar" "metrics-statsd-common-${STATSD_REPORTER_VERSION}.jar"
 cp -v "metrics-statsd-common-${STATSD_REPORTER_VERSION}.jar" ${LIB_DIR}
 
 # Metrics Config Parser library: build custom version with added statsd support (replaces cassandra-bin's version which currently lacks statsd)
-
 _package_github "addthis/metrics-reporter-config" "${REPORTER_CONFIG_SHA1}" "reporter-config${METRICS_INTERFACE_VERSION}/target/reporter-config${METRICS_INTERFACE_VERSION}-${REPORTER_CONFIG_VERSION_IN}.jar"
-
 rm -vf "${LIB_DIR}"/reporter-config*.jar
-
 cp -v \
    "metrics-reporter-config/reporter-config-base/target/reporter-config-base-${REPORTER_CONFIG_VERSION_IN}.jar" \
    "${LIB_DIR}/reporter-config-base-${REPORTER_CONFIG_VERSION_OUT}.jar"
-
 cp -v \
    "metrics-reporter-config/reporter-config${METRICS_INTERFACE_VERSION}/target/reporter-config${METRICS_INTERFACE_VERSION}-${REPORTER_CONFIG_VERSION_IN}.jar" \
    "${LIB_DIR}/reporter-config${METRICS_INTERFACE_VERSION}-${REPORTER_CONFIG_VERSION_OUT}.jar"
 
-sha1sum "${LIB_DIR}"/*.jar &> libdir-after.txt || true
+_sha1sum "${LIB_DIR}"/*.jar &> libdir-after.txt || true
 
-# Repack cassandra-bin package with library changes
+###
+# Rebuild cassandra-bin package with config and library changes
+###
 
 rm -vf ${CASSANDRA_CUSTOM_IMAGE}
 tar czf ${CASSANDRA_CUSTOM_IMAGE} ${CASSANDRA_DIST_NAME}
@@ -111,8 +144,12 @@ echo "#####"
 echo ""
 echo "CREATED: $(pwd)/${CASSANDRA_CUSTOM_IMAGE}"
 echo ""
-sha1sum ${CASSANDRA_DIST_NAME}*.tar.gz
+pwd
+_sha1sum ${CASSANDRA_DIST_NAME}*.tar.gz
 ls -l ${CASSANDRA_DIST_NAME}*.tar.gz
+echo ""
+echo "Summary of conf/ changes:"
+diff confdir-before.txt confdir-after.txt || true
 echo ""
 echo "Summary of lib/ changes:"
 diff libdir-before.txt libdir-after.txt || true

--- a/universe/package/resource.json
+++ b/universe/package/resource.json
@@ -4,7 +4,7 @@
       "scheduler-zip":"{{artifact-dir}}/scheduler.zip",
       "executor-zip":"{{artifact-dir}}/executor.zip",
       "jre-tar-gz":"https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/jre/linux/server-jre-8u74-linux-x64.tar.gz",
-      "apache-cassandra-bin-tar-gz":"https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/apache-cassandra-2.2.5-bin.tar.gz"
+      "apache-cassandra-bin-tar-gz":"https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/apache-cassandra-2.2.5-bin-dcos.tar.gz"
     }
   },
   "images": {


### PR DESCRIPTION
- Support OSX(?) with 'shasum' fallback if 'sha1sum' isn't available.
- Remove cassandra-[rackdc|topology].properties
- Disable (comment out) hardcoded JMX_PORT in cassandra-env.sh

Sample script output showing changes:

---

```
CREATED: /home/nick/code/dcos-cassandra-service/cassandra-bin-tmp/apache-cassandra-2.2.5-bin-dcos.tar.gz

/home/nick/code/dcos-cassandra-service/cassandra-bin-tmp
51ab15eced9e6dd4dcf4e6cb51693b1c2ce77cd9  apache-cassandra-2.2.5-bin-dcos.tar.gz
4ff19742595e8b532c8536dc3db0b42f1876948e  apache-cassandra-2.2.5-bin.tar.gz
-rw-rw-r-- 1 nick nick 29763365 May 24 11:28 apache-cassandra-2.2.5-bin-dcos.tar.gz
-rw-rw-r-- 1 nick nick 29522074 Feb  7 18:47 apache-cassandra-2.2.5-bin.tar.gz

Summary of conf/ changes:
2,4c2
< 2bd5bd097538dbda6ab265f3e0412b11637293b1  apache-cassandra-2.2.5/conf/cassandra-env.sh
< 3ea377bad43b53d319c312f55e1dca063d776fb5  apache-cassandra-2.2.5/conf/cassandra-rackdc.properties
< 3884ba5a33af3eda8417b1d8808a174701f76109  apache-cassandra-2.2.5/conf/cassandra-topology.properties

---
> 9df0707b9b5ba519bc2c8ba53552cdea4e29fd29  apache-cassandra-2.2.5/conf/cassandra-env.sh

Summary of lib/ changes:
31a32
> c5c6c4f52bdca0659f60845f966f503693f58e0c  apache-cassandra-2.2.5/lib/metrics3-statsd-4.1.2.jar
33a35
> d0d444eb4293fc7b9827d2f57081504795ca2ce3  apache-cassandra-2.2.5/lib/metrics-statsd-common-4.1.2.jar
37,38c39,41
< 8ee29824c98d1d4f2f323be9b590e4d49026c217  apache-cassandra-2.2.5/lib/reporter-config3-3.0.0.jar
< e3ad264a64b318e9940c0239affd0d1be8b8e11c  apache-cassandra-2.2.5/lib/reporter-config-base-3.0.0.jar

---
> da08365e0a4ba425bf44526f92a726976f88f4e7  apache-cassandra-2.2.5/lib/reporter-config3-3.0.1-595b3c23.jar
> 319a0d81b3e7dd5368d4e844cf08deca8f6a55d1  apache-cassandra-2.2.5/lib/reporter-config-base-3.0.1-595b3c23.jar
> 908b7f33ee7384a8dd91e01ffad9ed2abcf5ad57  apache-cassandra-2.2.5/lib/seedprovider-0.1.0.jar
```
