### PR TITLE
Use SchedulerDriverFactory, support framework auth

### DIFF
--- a/universe/package/config.json
+++ b/universe/package/config.json
@@ -20,6 +20,16 @@
 					"description": "The user that the service will run as.",
 					"default": "root"
 				},
+				"principal": {
+					"description": "The principal for the Cassandra service instance.",
+					"type": "string",
+					"default": "cassandra-principal"
+				},
+				"secret_name": {
+					"description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+					"type": "string",
+					"default": ""
+				},
 				"cpus": {
 					"id": "http://cassandra/docs/mesosphere.com/service/cpus",
 					"type": "number",

--- a/universe/package/marathon.json.mustache
+++ b/universe/package/marathon.json.mustache
@@ -51,10 +51,27 @@
   "minimumHealthCapacity": 0,
   "maximumOverCapacity": 0
 },
+{{#service.secret_name}}
+"secrets": {
+  "serviceCredential": {
+    "source": "{{service.secret_name}}"
+  }
+},
+{{/service.secret_name}}
 "env":{
+{{#service.secret_name}}
+"DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+"MESOS_MODULES": "file:///opt/mesosphere/etc/mesos-scheduler-modules/dcos_authenticatee_module.json",
+"MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+"SSL_CERT_FILE": "/run/dcos/pki/tls/certs/scheduler.crt",
+"SSL_KEY_FILE": "/run/dcos/pki/tls/private/scheduler.key",
+"SSL_CA_FILE": "/run/dcos/pki/CA/certs/ca.crt",
+"SSL_ENABLED": "true",
+{{/service.secret_name}}
 "JAVA_HOME":"./jre"
 ,"JAVA_OPTS":"-Xmx{{service.heap}}M"
 ,"FRAMEWORK_NAME":"{{service.name}}"
+,"FRAMEWORK_PRINCIPAL": "{{service.principal}}"
 ,"FRAMEWORK_VERSION":"1.0.0"
 ,"CASSANDRA_VERSION":"2.2.5"
 ,"CASSANDRA_CPUS":"{{nodes.cpus}}"


### PR DESCRIPTION
This is effectively a no-op if the secret_name value is left empty (the default).

Exposes principal setting while maintaining the current default 'cassandra-principal'. This needs to be configurable by the user in an auth scenario as it's effectively treated as a 'username' for auth.
