### PR TITLE
Tweaks to CLI build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ out/
 .classpath
 .project
 .settings/
+cassandra-*/bin/
 
 # Mac
 .DS_Store

--- a/cli/bin/env.sh
+++ b/cli/bin/env.sh
@@ -22,15 +22,16 @@ if [ ! -d "$BASEDIR/env" ]; then
 fi
 
 cd $BASEDIR
-if [ "$(uname)" == "Darwin" ]; then
+uname -a
+if [ "$(uname)" = "Darwin" -o "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
     source $BASEDIR/env/bin/activate
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    source $BASEDIR/env/bin/activate
-elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
-    source $BASEDIR/env/Scripts/activate
+    echo "Virtualenv activated."
+else
+    # apparently not needed on Windows
+    echo "Skipping virtualenv activation."
 fi
-echo "Virtualenv activated."
 
+echo "Installing requirements..."
 if [ ! -f "$BASEDIR/env/updated" -o $BASEDIR/setup.py -nt $BASEDIR/env/updated ]; then
     pip install -e $BASEDIR
     touch $BASEDIR/env/updated

--- a/cli/bin/packages.sh
+++ b/cli/bin/packages.sh
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo "Building wheel..."
 BASEDIR=`dirname $0`/..
 
 if [ ! -d "$BASEDIR/env" ]; then
@@ -23,15 +22,16 @@ if [ ! -d "$BASEDIR/env" ]; then
 fi
 
 cd $BASEDIR
-if [ "$(uname)" == "Darwin" ]; then
+uname -a
+if [ "$(uname)" = "Darwin" -o "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
     source $BASEDIR/env/bin/activate
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    source $BASEDIR/env/bin/activate
-elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
-    source $BASEDIR/env/Scripts/activate
+    echo "Virtualenv activated."
+else
+    # apparently not needed on Windows
+    echo "Skipping virtualenv activation."
 fi
-echo "Virtualenv activated."
 
+echo "Building wheel..."
 python setup.py bdist_wheel
 
 echo "Building egg..."


### PR DESCRIPTION
The Windows build was failing the OS check entirely, effectively making it a no-op. Make the no-op official, while also fixing the check.

From last kafka CLI windows build:
C:\Windows\workspace\kafka\cli\windows-x86-64\cli\bin\packages.sh: [: ==: binary operator expected
C:\Windows\workspace\kafka\cli\windows-x86-64\cli\bin\packages.sh: [: ==: binary operator expected
C:\Windows\workspace\kafka\cli\windows-x86-64\cli\bin\packages.sh: [: ==: binary operator expected
