### PR TITLE
BREAKING CHANGE: Update cassandra to latest storage

### DIFF
--- a/cassandra-commons/build.gradle
+++ b/cassandra-commons/build.gradle
@@ -3,7 +3,7 @@ targetCompatibility = '1.8'
 
 apply plugin: 'com.google.protobuf'
 dependencies {
-    compile "mesosphere:dcos-commons:0.4.23-SNAPSHOT"
+    compile "mesosphere:dcos-commons:0.4.26-SNAPSHOT"
     compile 'org.apache.cassandra:cassandra-all:2.2.4'
 }
 protobuf {

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/SchedulerModule.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/SchedulerModule.java
@@ -36,14 +36,12 @@ import org.apache.curator.retry.RetryForever;
 import org.apache.curator.retry.RetryUntilElapsed;
 import org.apache.http.client.HttpClient;
 import org.apache.mesos.config.ConfigStoreException;
+import org.apache.mesos.curator.CuratorStateStore;
 import org.apache.mesos.reconciliation.DefaultReconciler;
 import org.apache.mesos.reconciliation.Reconciler;
 import org.apache.mesos.scheduler.plan.PhaseStrategyFactory;
 import org.apache.mesos.scheduler.plan.StageManager;
-import org.apache.mesos.state.CuratorStateStore;
 import org.apache.mesos.state.StateStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -51,8 +49,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 public class SchedulerModule extends AbstractModule {
-    private final static Logger LOGGER = LoggerFactory.getLogger(
-            SchedulerModule.class);
 
     private final CassandraSchedulerConfiguration configuration;
     private final Environment environment;
@@ -88,16 +84,16 @@ public class SchedulerModule extends AbstractModule {
                         new RetryForever((int) curatorConfig.getBackoffMs());
 
         CuratorStateStore curatorStateStore = new CuratorStateStore(
-                "/" + configuration.getServiceConfig().getName(),
+                configuration.getServiceConfig().getName(),
                 curatorConfig.getServers(),
                 retryPolicy);
         bind(StateStore.class).toInstance(curatorStateStore);
 
         try {
             final ConfigValidator configValidator = new ConfigValidator();
-            final DefaultConfigurationManager configurationManager
-                    = new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
-                    "/" + configuration.getServiceConfig().getName(),
+            final DefaultConfigurationManager configurationManager =
+                    new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
+                    configuration.getServiceConfig().getName(),
                     curatorConfig.getServers(),
                     configuration,
                     configValidator,

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/client/SchedulerClient.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/client/SchedulerClient.java
@@ -114,7 +114,7 @@ public class SchedulerClient {
 
     private CompletionStage<Boolean> delete(String url) {
         LOGGER.debug("Executing delete: url = {}", url);
-        CompletableFuture promise = new CompletableFuture<Boolean>();
+        CompletableFuture<Boolean> promise = new CompletableFuture<Boolean>();
         executor.submit(() -> {
            HttpDelete delete = new HttpDelete(url);
             try {
@@ -159,7 +159,7 @@ public class SchedulerClient {
 
     private CompletionStage<Boolean> put(String url, Object json) {
         LOGGER.debug("Executing put: url = {}, data = {}", url, json);
-        CompletableFuture promise = new CompletableFuture<Boolean>();
+        CompletableFuture<Boolean> promise = new CompletableFuture<Boolean>();
         executor.submit(() -> {
             HttpPut put = new HttpPut(url);
             try {
@@ -186,27 +186,6 @@ public class SchedulerClient {
         });
         return promise;
     }
-
-    private CompletionStage<Boolean> put(String host,
-                                         String path,
-                                         Object json) {
-        try {
-            return put(new URIBuilder()
-                            .setScheme(SCHEME)
-                            .setHost(host)
-                            .setPath(path)
-                            .build().toString(),
-                    json);
-        } catch (Throwable t) {
-            LOGGER.error(String.format(
-                    "Put request failed: host = %s, path = %s",
-                    host,
-                    path),
-                    t);
-            return failure(t);
-        }
-    }
-
 
     public CompletionStage<CassandraStatus> status(String hostname, int port) {
         return get(host(hostname, port), "/v1/cassandra/status", CassandraStatus

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/YAMLConfigurationFactory.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/YAMLConfigurationFactory.java
@@ -9,10 +9,10 @@ import org.apache.mesos.config.ConfigStoreException;
 import org.apache.mesos.config.Configuration;
 import org.apache.mesos.config.ConfigurationFactory;
 
-public class YAMLConfigurationFactory implements ConfigurationFactory {
-    private Class typeParameterClass;
+public class YAMLConfigurationFactory implements ConfigurationFactory<Configuration> {
+    private Class<?> typeParameterClass;
 
-    public YAMLConfigurationFactory(Class typeParameterClass) {
+    public YAMLConfigurationFactory(Class<?> typeParameterClass) {
         this.typeParameterClass = typeParameterClass;
     }
 

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/seeds/SeedsManager.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/seeds/SeedsManager.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
@@ -114,8 +113,7 @@ public class SeedsManager implements Runnable {
         try {
             synchronized (stateStore) {
                 LOGGER.info("Loading data from persistent store");
-                final Collection<String> propertyKeys = stateStore.listPropertyKeys();
-                for (final String key : propertyKeys) {
+                for (final String key : stateStore.fetchPropertyKeys()) {
                     if (!key.startsWith(DATA_CENTERS_KEY)) {
                         continue;
                     }

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/config/ConfigurationManagerTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/config/ConfigurationManagerTest.java
@@ -4,7 +4,6 @@ package com.mesosphere.dcos.cassandra.scheduler.config;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.io.Resources;
-import com.mesosphere.dcos.cassandra.common.config.CassandraConfig;
 import com.mesosphere.dcos.cassandra.common.config.ExecutorConfig;
 import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
@@ -16,7 +15,7 @@ import org.apache.curator.RetryPolicy;
 import org.apache.curator.retry.RetryForever;
 import org.apache.curator.retry.RetryUntilElapsed;
 import org.apache.curator.test.TestingServer;
-import org.apache.mesos.state.CuratorStateStore;
+import org.apache.mesos.curator.CuratorStateStore;
 import org.apache.mesos.state.StateStore;
 import org.junit.After;
 import org.junit.Before;
@@ -26,7 +25,6 @@ import java.net.URI;
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
 
 public class ConfigurationManagerTest {
     private static TestingServer server;
@@ -67,12 +65,12 @@ public class ConfigurationManagerTest {
                         new RetryForever((int) curatorConfig.getBackoffMs());
 
         StateStore stateStore = new CuratorStateStore(
-                "/" + original.getServiceConfig().getName(),
+                original.getServiceConfig().getName(),
                 server.getConnectString(),
                 retryPolicy);
-        DefaultConfigurationManager configurationManager
-                = new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
-                "/" + original.getServiceConfig().getName(),
+        DefaultConfigurationManager configurationManager =
+                new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
+                original.getServiceConfig().getName(),
                 connectString,
                 original,
                 new ConfigValidator(),
@@ -114,12 +112,12 @@ public class ConfigurationManagerTest {
                         new RetryForever((int) curatorConfig.getBackoffMs());
 
         StateStore stateStore = new CuratorStateStore(
-                "/" + original.getServiceConfig().getName(),
+                original.getServiceConfig().getName(),
                 server.getConnectString(),
                 retryPolicy);
         DefaultConfigurationManager configurationManager
                 = new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
-                "/" + original.getServiceConfig().getName(),
+                original.getServiceConfig().getName(),
                 connectString,
                 original,
                 new ConfigValidator(),
@@ -170,9 +168,9 @@ public class ConfigurationManagerTest {
 
         CassandraSchedulerConfiguration updated = mutable.createConfig();
 
-        configurationManager
-                = new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
-                "/" + original.getServiceConfig().getName(),
+        configurationManager =
+                new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
+                original.getServiceConfig().getName(),
                 connectString,
                 updated,
                 new ConfigValidator(),
@@ -211,12 +209,12 @@ public class ConfigurationManagerTest {
                         new RetryForever((int) curatorConfig.getBackoffMs());
 
         StateStore stateStore = new CuratorStateStore(
-                "/" + originalConfig.getServiceConfig().getName(),
+                originalConfig.getServiceConfig().getName(),
                 server.getConnectString(),
                 retryPolicy);
-        DefaultConfigurationManager configurationManager
-                = new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
-                "/" + originalConfig.getServiceConfig().getName(),
+        DefaultConfigurationManager configurationManager =
+                new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
+                originalConfig.getServiceConfig().getName(),
                 connectString,
                 originalConfig,
                 new ConfigValidator(),
@@ -236,9 +234,9 @@ public class ConfigurationManagerTest {
         int updatedServers = originalConfig.getServers() - 1;
         mutable.setServers(updatedServers);
 
-        configurationManager
-                = new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
-                "/" + originalConfig.getServiceConfig().getName(),
+        configurationManager =
+                new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
+                originalConfig.getServiceConfig().getName(),
                 connectString,
                 mutable.createConfig(),
                 new ConfigValidator(),
@@ -269,12 +267,12 @@ public class ConfigurationManagerTest {
                         new RetryForever((int) curatorConfig.getBackoffMs());
 
         StateStore stateStore = new CuratorStateStore(
-                "/" + originalConfig.getServiceConfig().getName(),
+                originalConfig.getServiceConfig().getName(),
                 server.getConnectString(),
                 retryPolicy);
         DefaultConfigurationManager configurationManager
                 = new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
-                "/" + originalConfig.getServiceConfig().getName(),
+                originalConfig.getServiceConfig().getName(),
                 connectString,
                 originalConfig,
                 new ConfigValidator(),
@@ -294,9 +292,9 @@ public class ConfigurationManagerTest {
         int updatedSeeds = originalConfig.getServers() + 1;
         mutableSchedulerConfiguration.setSeeds(updatedSeeds);
 
-        configurationManager
-                = new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
-                "/" + originalConfig.getServiceConfig().getName(),
+        configurationManager =
+                new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
+                originalConfig.getServiceConfig().getName(),
                 connectString,
                 mutableSchedulerConfiguration.createConfig(),
                 new ConfigValidator(),

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/offer/ClusterTaskOfferRequirementProviderTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/offer/ClusterTaskOfferRequirementProviderTest.java
@@ -18,10 +18,10 @@ import org.apache.curator.retry.RetryForever;
 import org.apache.curator.retry.RetryUntilElapsed;
 import org.apache.curator.test.TestingServer;
 import org.apache.mesos.Protos;
+import org.apache.mesos.curator.CuratorStateStore;
 import org.apache.mesos.offer.OfferRequirement;
 import org.apache.mesos.protobuf.ResourceBuilder;
 import org.apache.mesos.protobuf.TaskInfoBuilder;
-import org.apache.mesos.state.CuratorStateStore;
 import org.apache.mesos.state.StateStore;
 import org.junit.*;
 
@@ -123,7 +123,7 @@ public class ClusterTaskOfferRequirementProviderTest {
                         new RetryForever((int) curatorConfig.getBackoffMs());
 
         stateStore = new CuratorStateStore(
-                "/" + config.getServiceConfig().getName(),
+                config.getServiceConfig().getName(),
                 server.getConnectString(),
                 retryPolicy);
         stateStore.storeFrameworkId(Protos.FrameworkID.newBuilder().setValue("1234").build());
@@ -133,9 +133,9 @@ public class ClusterTaskOfferRequirementProviderTest {
 
         identity.register("test_id");
 
-        DefaultConfigurationManager configurationManager
-                = new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
-                "/" + config.getServiceConfig().getName(),
+        DefaultConfigurationManager configurationManager =
+                new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
+                config.getServiceConfig().getName(),
                 server.getConnectString(),
                 config,
                 new ConfigValidator(),

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConfigurationResourceTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConfigurationResourceTest.java
@@ -17,7 +17,7 @@ import org.apache.curator.RetryPolicy;
 import org.apache.curator.retry.RetryForever;
 import org.apache.curator.retry.RetryUntilElapsed;
 import org.apache.curator.test.TestingServer;
-import org.apache.mesos.state.CuratorStateStore;
+import org.apache.mesos.curator.CuratorStateStore;
 import org.apache.mesos.state.StateStore;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -66,12 +66,12 @@ public class ConfigurationResourceTest {
                         new RetryForever((int) curatorConfig.getBackoffMs());
 
         StateStore stateStore = new CuratorStateStore(
-                "/" + config.getServiceConfig().getName(),
+                config.getServiceConfig().getName(),
                 server.getConnectString(),
                 retryPolicy);
-        configurationManager
-                = new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
-                "/" + config.getServiceConfig().getName(),
+        configurationManager =
+                new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
+                config.getServiceConfig().getName(),
                 server.getConnectString(),
                 config,
                 new ConfigValidator(),

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/resources/ServiceConfigResourceTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/resources/ServiceConfigResourceTest.java
@@ -16,7 +16,7 @@ import org.apache.curator.retry.RetryForever;
 import org.apache.curator.retry.RetryUntilElapsed;
 import org.apache.curator.test.TestingServer;
 import org.apache.mesos.config.ConfigStoreException;
-import org.apache.mesos.state.CuratorStateStore;
+import org.apache.mesos.curator.CuratorStateStore;
 import org.apache.mesos.state.StateStore;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -57,8 +57,6 @@ public class ServiceConfigResourceTest {
                         new EnvironmentVariableSubstitutor(false, true)),
                 Resources.getResource("scheduler.yml").getFile());
 
-        ServiceConfig initial = config.getServiceConfig();
-
         final CuratorFrameworkConfig curatorConfig = config.getCuratorConfig();
         RetryPolicy retryPolicy =
                 (curatorConfig.getOperationTimeout().isPresent()) ?
@@ -70,16 +68,16 @@ public class ServiceConfigResourceTest {
                         new RetryForever((int) curatorConfig.getBackoffMs());
 
         stateStore = new CuratorStateStore(
-                "/" + config.createConfig().getServiceConfig().getName(),
+                config.createConfig().getServiceConfig().getName(),
                 server.getConnectString(),
                 retryPolicy);
 
         final CassandraSchedulerConfiguration configuration = config.createConfig();
         try {
             final ConfigValidator configValidator = new ConfigValidator();
-            final DefaultConfigurationManager defaultConfigurationManager
-                    = new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
-                    "/" + configuration.getServiceConfig().getName(),
+            final DefaultConfigurationManager defaultConfigurationManager =
+                    new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
+                    configuration.getServiceConfig().getName(),
                     server.getConnectString(),
                     configuration,
                     configValidator,

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/tasks/CassandraTasksTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/tasks/CassandraTasksTest.java
@@ -17,10 +17,10 @@ import org.apache.curator.retry.RetryForever;
 import org.apache.curator.retry.RetryUntilElapsed;
 import org.apache.curator.test.TestingServer;
 import org.apache.mesos.Protos;
+import org.apache.mesos.curator.CuratorStateStore;
 import org.apache.mesos.offer.ResourceUtils;
 import org.apache.mesos.offer.TaskException;
 import org.apache.mesos.offer.TaskUtils;
-import org.apache.mesos.state.CuratorStateStore;
 import org.apache.mesos.state.StateStore;
 import org.junit.After;
 import org.junit.Assert;
@@ -39,7 +39,6 @@ public class CassandraTasksTest {
     private static MutableSchedulerConfiguration config;
     private static IdentityManager identity;
     private static ConfigurationManager configuration;
-    private static CuratorFrameworkConfig curatorConfig;
     private static ClusterTaskConfig clusterTaskConfig;
     private static String testDaemonName = "test-daemon-name";
     private static String testHostName = "test-host-name";
@@ -70,12 +69,6 @@ public class CassandraTasksTest {
 
         ServiceConfig initial = config.createConfig().getServiceConfig();
 
-        curatorConfig = CuratorFrameworkConfig.create(server.getConnectString(),
-                10000L,
-                10000L,
-                Optional.empty(),
-                250L);
-
         final CassandraSchedulerConfiguration targetConfig = config.createConfig();
         clusterTaskConfig = targetConfig.getClusterTaskConfig();
 
@@ -90,7 +83,7 @@ public class CassandraTasksTest {
                         new RetryForever((int) curatorConfig.getBackoffMs());
 
         stateStore = new CuratorStateStore(
-                "/" + targetConfig.getServiceConfig().getName(),
+                targetConfig.getServiceConfig().getName(),
                 server.getConnectString(),
                 retryPolicy);
         stateStore.storeFrameworkId(Protos.FrameworkID.newBuilder().setValue("1234").build());
@@ -99,9 +92,9 @@ public class CassandraTasksTest {
 
         identity.register("test_id");
 
-        DefaultConfigurationManager configurationManager
-                = new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
-                "/" + config.createConfig().getServiceConfig().getName(),
+        DefaultConfigurationManager configurationManager =
+                new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
+                config.createConfig().getServiceConfig().getName(),
                 server.getConnectString(),
                 config.createConfig(),
                 new ConfigValidator(),


### PR DESCRIPTION
dcos-commons has added a '/dcos-service-' prefix to the start of
the state/config ZK path, to avoid eg a framework named 'mesos'
breaking everything. All the curator-specific code in commons was
broken out into its own 'curator' package as well.
