### PR TITLE
Move serialized object members to snake_case

### DIFF
--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/cleanup/CleanupContext.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/cleanup/CleanupContext.java
@@ -84,16 +84,16 @@ public class CleanupContext implements ClusterTaskContext {
     @JsonCreator
     public static CleanupContext create(
             @JsonProperty("nodes") final List<String> nodes,
-            @JsonProperty("keySpaces") final List<String> keySpaces,
-            @JsonProperty("columnFamilies") final List<String> columnFamilies) {
+            @JsonProperty("key_spaces") final List<String> keySpaces,
+            @JsonProperty("column_families") final List<String> columnFamilies) {
         return new CleanupContext(nodes, keySpaces, columnFamilies);
     }
 
     @JsonProperty("nodes")
     private final List<String> nodes;
-    @JsonProperty("keySpaces")
+    @JsonProperty("key_spaces")
     private final List<String> keySpaces;
-    @JsonProperty("columnFamilies")
+    @JsonProperty("column_families")
     private final List<String> columnFamilies;
 
     /**

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/repair/RepairContext.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/repair/RepairContext.java
@@ -77,16 +77,16 @@ public class RepairContext implements ClusterTaskContext {
     @JsonCreator
     public static RepairContext create(
         @JsonProperty("nodes") final List<String> nodes,
-        @JsonProperty("keySpaces") final List<String> keySpaces,
-        @JsonProperty("columnFamilies") final List<String> columnFamilies) {
+        @JsonProperty("key_spaces") final List<String> keySpaces,
+        @JsonProperty("column_families") final List<String> columnFamilies) {
         return new RepairContext(nodes, keySpaces, columnFamilies);
     }
 
     @JsonProperty("nodes")
     private final List<String> nodes;
-    @JsonProperty("keySpaces")
+    @JsonProperty("key_spaces")
     private final List<String> keySpaces;
-    @JsonProperty("columnFamilies")
+    @JsonProperty("column_families")
     private final List<String> columnFamilies;
 
     /**

--- a/cassandra-commons/src/test/java/com/mesosphere/dcos/cassandra/common/tasks/cleanup/CleanupContextTest.java
+++ b/cassandra-commons/src/test/java/com/mesosphere/dcos/cassandra/common/tasks/cleanup/CleanupContextTest.java
@@ -1,0 +1,35 @@
+package com.mesosphere.dcos.cassandra.common.tasks.cleanup;
+
+import com.google.common.collect.Iterators;
+import com.mesosphere.dcos.cassandra.common.util.JsonUtils;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class CleanupContextTest {
+    @Test
+    public void testJSONSerializationWithSnakeCaseMembers() throws Exception {
+        CleanupContext context = new CleanupContext(
+                Arrays.asList("node1"), Arrays.asList("keyspace1"), Arrays.asList("column_family1"));
+        ObjectMapper om = new ObjectMapper();
+
+        String jsonContext = new String(CleanupContext.JSON_SERIALIZER.serialize(context), "ISO-8859-1");
+
+        JsonNode rehydratedContext = om.readTree(jsonContext);
+        List<String> keys = new ArrayList<>();
+        Iterators.addAll(keys, rehydratedContext.getFieldNames());
+        keys.sort(String::compareTo);
+
+        Assert.assertEquals(Arrays.asList("column_families", "key_spaces", "nodes"), keys);
+
+        context = JsonUtils.MAPPER.readValue(jsonContext, CleanupContext.class);
+        Assert.assertEquals(Arrays.asList("column_family1"), context.getColumnFamilies());
+        Assert.assertEquals(Arrays.asList("keyspace1"), context.getKeySpaces());
+        Assert.assertEquals(Arrays.asList("node1"), context.getNodes());
+    }
+}

--- a/cassandra-commons/src/test/java/com/mesosphere/dcos/cassandra/common/tasks/repair/RepairContextTest.java
+++ b/cassandra-commons/src/test/java/com/mesosphere/dcos/cassandra/common/tasks/repair/RepairContextTest.java
@@ -1,0 +1,35 @@
+package com.mesosphere.dcos.cassandra.common.tasks.repair;
+
+import com.google.common.collect.Iterators;
+import com.mesosphere.dcos.cassandra.common.util.JsonUtils;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class RepairContextTest {
+    @Test
+    public void testJSONSerializationWithSnakeCaseMembers() throws Exception {
+        RepairContext context = new RepairContext(
+                Arrays.asList("node1"), Arrays.asList("keyspace1"), Arrays.asList("column_family1"));
+        ObjectMapper om = new ObjectMapper();
+
+        String jsonContext = new String(RepairContext.JSON_SERIALIZER.serialize(context), "ISO-8859-1");
+
+        JsonNode rehydratedContext = om.readTree(jsonContext);
+        List<String> keys = new ArrayList<>();
+        Iterators.addAll(keys, rehydratedContext.getFieldNames());
+        keys.sort(String::compareTo);
+
+        Assert.assertEquals(Arrays.asList("column_families", "key_spaces", "nodes"), keys);
+
+        context = JsonUtils.MAPPER.readValue(jsonContext, RepairContext.class);
+        Assert.assertEquals(Arrays.asList("column_family1"), context.getColumnFamilies());
+        Assert.assertEquals(Arrays.asList("keyspace1"), context.getKeySpaces());
+        Assert.assertEquals(Arrays.asList("node1"), context.getNodes());
+    }
+}


### PR DESCRIPTION
All field names in JSON-serialized objects should be in snake case. A quick summary of the changes to objects returned:

### CassandraApplicationConfig
`rpcAddress` -> `rpc_address`
### CleanupContext
`columnFamilies` -> `column_families`
`keySpaces` -> `key_spaces`
### RepairContext
`columnFamilies` -> `column_families`
`keySpaces` -> `key_spaces`