### PR TITLE
Handles TASK_STATUS with missing data field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ cassandra-bin-tmp/
 dcos-commons-tools/
 
 cassandra-scheduler/cassandra.yaml
+
+.cache/
+__pycache__/

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonBlockTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonBlockTest.java
@@ -367,4 +367,58 @@ public class CassandraDaemonBlockTest {
 
         Assert.assertEquals(mockOfferReq, block.start());
     }
+
+    @Test
+    public void testUpdateDataPresent() throws Exception {
+        final String EXPECTED_NAME = "node-0";
+        CassandraDaemonBlock block = CassandraDaemonBlock.create(
+                EXPECTED_NAME, persistentOfferRequirementProvider, cassandraTasks, client);
+
+        final OfferRequirement mockOfferReq = Mockito.mock(OfferRequirement.class);
+        when(persistentOfferRequirementProvider.getNewOfferRequirement(Mockito.any())).thenReturn(mockOfferReq);
+
+        OfferRequirement offerRequirement = block.start();
+        Assert.assertNotNull(offerRequirement);
+
+        final CassandraDaemonTask task = CassandraDaemonTask.create(EXPECTED_NAME,
+                "abc",
+                CassandraTaskExecutor.create("1234", EXPECTED_NAME, "cassandra-role", "cassandra-principal", config.getExecutorConfig()),
+                config.getCassandraConfig());
+        Protos.TaskInfo taskInfo = task.getTaskInfo();
+        taskInfo = Protos.TaskInfo.newBuilder(taskInfo)
+                .setSlaveId(Protos.SlaveID.newBuilder().setValue("1.2.3.4").build()).build();
+        stateStore.storeTasks(Arrays.asList(taskInfo));
+        block.updateOfferStatus(true);
+        final Protos.TaskStatus status = TestUtils.generateStatus(taskInfo.getTaskId(),
+                Protos.TaskState.TASK_RUNNING, CassandraMode.NORMAL);
+
+        block.update(status);
+    }
+
+    @Test
+    public void testUpdateDataNotPresent() throws Exception {
+        final String EXPECTED_NAME = "node-0";
+        CassandraDaemonBlock block = CassandraDaemonBlock.create(
+                EXPECTED_NAME, persistentOfferRequirementProvider, cassandraTasks, client);
+
+        final OfferRequirement mockOfferReq = Mockito.mock(OfferRequirement.class);
+        when(persistentOfferRequirementProvider.getNewOfferRequirement(Mockito.any())).thenReturn(mockOfferReq);
+
+        OfferRequirement offerRequirement = block.start();
+        Assert.assertNotNull(offerRequirement);
+
+        final CassandraDaemonTask task = CassandraDaemonTask.create(EXPECTED_NAME,
+                "abc",
+                CassandraTaskExecutor.create("1234", EXPECTED_NAME, "cassandra-role", "cassandra-principal", config.getExecutorConfig()),
+                config.getCassandraConfig());
+        Protos.TaskInfo taskInfo = task.getTaskInfo();
+        taskInfo = Protos.TaskInfo.newBuilder(taskInfo)
+                .setSlaveId(Protos.SlaveID.newBuilder().setValue("1.2.3.4").build()).build();
+        stateStore.storeTasks(Arrays.asList(taskInfo));
+        block.updateOfferStatus(true);
+        final Protos.TaskStatus status = TestUtils.generateStatus(taskInfo.getTaskId(),
+                Protos.TaskState.TASK_RUNNING);
+
+        block.update(status);
+    }
 }

--- a/integration/tests/command.py
+++ b/integration/tests/command.py
@@ -117,7 +117,7 @@ def uninstall():
 
         return shakedown.run_command_on_master(
             'docker run mesosphere/janitor /janitor.py '
-            '-r cassandra-role -p cassandra-principal -z cassandra'
+            '-r cassandra-role -p cassandra-principal -z dcos-service-cassandra'
         )
 
     spin(fn, lambda x: (x, 'Uninstall failed'))


### PR DESCRIPTION
There are some scenarios where `TASK_STATUS` can be sent without the `data` field set:
1. Reconciliation
2. When the status is sent by `Agent` and not `Executor`.

This PR handles those scenarios. 

If not handled, than it can lead to failure at runtime, causing a failure to record TASK_STATUS, leaving the state-machine in an incorrect state, and hence prevent scheduler from taking remedial actions.
