### PR TITLE
Deprecate "/v1/nodes/connect" and replace with "/v1/connection"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1789,7 +1789,7 @@ $ curl -H "Authorization:token=<auth_token>" <dcos_url>/service/cassandra/v1/pla
 ### Retrieve Connection Info
 
 ```
-$ curl -H "Authorization:token=<auth_token>" <dcos_url>/cassandra/v1/nodes/connect
+$ curl -H "Authorization:token=<auth_token>" <dcos_url>/cassandra/v1/connect
 ```
 
 You will see a response similar to the following:

--- a/README.md
+++ b/README.md
@@ -1789,7 +1789,7 @@ $ curl -H "Authorization:token=<auth_token>" <dcos_url>/service/cassandra/v1/pla
 ### Retrieve Connection Info
 
 ```
-$ curl -H "Authorization:token=<auth_token>" <dcos_url>/cassandra/v1/connect
+$ curl -H "Authorization:token=<auth_token>" <dcos_url>/cassandra/v1/connection
 ```
 
 You will see a response similar to the following:

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/Main.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/Main.java
@@ -93,6 +93,9 @@ public class Main extends Application<MutableSchedulerConfiguration> {
     environment.jersey().register(
       injector.getInstance(DataCenterResource.class)
     );
+    environment.jersey().register(
+            injector.getInstance(ConnectionResource.class)
+    );
   }
 
   private void registerManagedObjects(Environment environment, Injector injector) {

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResource.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResource.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-@Path("/v1/connect")
+@Path("/v1/connection")
 @Produces(MediaType.APPLICATION_JSON)
 public class ConnectionResource {
     private final CassandraTasks tasks;

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResource.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResource.java
@@ -1,0 +1,86 @@
+package com.mesosphere.dcos.cassandra.scheduler.resources;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.mesosphere.dcos.cassandra.common.tasks.CassandraDaemonTask;
+import com.mesosphere.dcos.cassandra.scheduler.config.ConfigurationManager;
+import com.mesosphere.dcos.cassandra.scheduler.config.ServiceConfig;
+import com.mesosphere.dcos.cassandra.scheduler.tasks.CassandraTasks;
+import org.apache.mesos.Protos;
+import org.apache.mesos.config.ConfigStoreException;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Path("/v1/connect")
+@Produces(MediaType.APPLICATION_JSON)
+public class ConnectionResource {
+    private final CassandraTasks tasks;
+    private final ConfigurationManager configurationManager;
+
+    @Inject
+    public ConnectionResource(final CassandraTasks tasks,
+                              final ConfigurationManager configurationManager) {
+        this.tasks = tasks;
+        this.configurationManager = configurationManager;
+    }
+
+    @GET
+    public Map<String, List<String>> connect() throws ConfigStoreException {
+
+        return ImmutableMap.of("address", getRunningAddresses(),
+                "dns", getRunningDns());
+    }
+
+    @GET
+    @Path("/address")
+    public List<String> connectAddress() {
+        return getRunningAddresses();
+    }
+
+    @GET
+    @Path("/dns")
+    public List<String> connectDns() throws ConfigStoreException {
+        return getRunningDns();
+    }
+
+    @VisibleForTesting
+    protected List<String> getRunningAddresses() {
+
+        return getRunningDeamons().stream().map(daemonTask ->
+                daemonTask.getHostname() +
+                        ":" +
+                        daemonTask.getConfig()
+                                .getApplication()
+                                .getNativeTransportPort())
+                .collect(Collectors.toList());
+    }
+
+    @VisibleForTesting
+    protected List<String> getRunningDns() throws ConfigStoreException {
+        final ServiceConfig serviceConfig = configurationManager.getTargetConfig().getServiceConfig();
+        return getRunningDeamons().stream().map(daemonTask ->
+                daemonTask.getName() +
+                        "." + serviceConfig.getName() + ".mesos:" +
+                        daemonTask.getConfig()
+                                .getApplication()
+                                .getNativeTransportPort()
+        ).collect(Collectors.toList());
+    }
+
+    @VisibleForTesting
+    protected List<CassandraDaemonTask> getRunningDeamons() {
+        return tasks.getDaemons().values().stream()
+                .filter
+                        (daemonTask ->
+                                Protos.TaskState.TASK_RUNNING.equals(
+                                        daemonTask.getState())).collect
+                        (Collectors.toList());
+    }
+}

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResource.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResource.java
@@ -33,7 +33,6 @@ public class ConnectionResource {
 
     @GET
     public Map<String, List<String>> connect() throws ConfigStoreException {
-
         return ImmutableMap.of("address", getRunningAddresses(),
                 "dns", getRunningDns());
     }
@@ -52,7 +51,6 @@ public class ConnectionResource {
 
     @VisibleForTesting
     protected List<String> getRunningAddresses() {
-
         return getRunningDeamons().stream().map(daemonTask ->
                 daemonTask.getHostname() +
                         ":" +

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/TasksResource.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/TasksResource.java
@@ -16,12 +16,15 @@
 
 package com.mesosphere.dcos.cassandra.scheduler.resources;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.protobuf.TextFormat;
 import com.mesosphere.dcos.cassandra.common.tasks.CassandraContainer;
 import com.mesosphere.dcos.cassandra.common.tasks.CassandraDaemonTask;
 import com.mesosphere.dcos.cassandra.scheduler.client.SchedulerClient;
+import com.mesosphere.dcos.cassandra.scheduler.config.ConfigurationManager;
 import com.mesosphere.dcos.cassandra.scheduler.tasks.CassandraTasks;
+import org.apache.mesos.config.ConfigStoreException;
 import org.glassfish.jersey.server.ManagedAsync;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +36,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Path("/v1/nodes")
@@ -42,12 +46,15 @@ public class TasksResource {
             (TasksResource.class);
     private final CassandraTasks tasks;
     private final SchedulerClient client;
+    private final ConfigurationManager configurationManager;
 
     @Inject
     public TasksResource(final CassandraTasks tasks,
-                         final SchedulerClient client) {
+                         final SchedulerClient client,
+                         final ConfigurationManager configurationManager) {
         this.tasks = tasks;
         this.client = client;
+        this.configurationManager = configurationManager;
     }
 
     @GET
@@ -126,5 +133,38 @@ public class TasksResource {
         } else {
             throw new NotFoundException();
         }
+    }
+
+    /**
+     * Deprecated. See {@code ConnectionResource}.
+     */
+    @GET
+    @Path("connect")
+    @Deprecated
+    public Map<String, List<String>> connect() throws ConfigStoreException {
+        final ConnectionResource connectionResource = new ConnectionResource(tasks, configurationManager);
+        return connectionResource.connect();
+    }
+
+    /**
+     * Deprecated. See {@code ConnectionResource}.
+     */
+    @GET
+    @Path("connect/address")
+    @Deprecated
+    public List<String> connectAddress() {
+        final ConnectionResource connectionResource = new ConnectionResource(tasks, configurationManager);
+        return connectionResource.connectAddress();
+    }
+
+    /**
+     * Deprecated. See {@code ConnectionResource}.
+     */
+    @GET
+    @Path("connect/dns")
+    @Deprecated
+    public List<String> connectDns() throws ConfigStoreException {
+        final ConnectionResource connectionResource = new ConnectionResource(tasks, configurationManager);
+        return connectionResource.connectDns();
     }
 }

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResourceTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResourceTest.java
@@ -96,7 +96,7 @@ public class ConnectionResourceTest {
 
     @Test
     public void testGetConnectEmpty() throws Exception {
-        final Map map = resources.client().target("/v1/connect").request().get(Map.class);
+        final Map map = resources.client().target("/v1/connection").request().get(Map.class);
         final Object address = map.get("address");
         final Object dns = map.get("dns");
         Assert.assertNotNull(address);
@@ -105,13 +105,13 @@ public class ConnectionResourceTest {
 
     @Test
     public void testGetAddressEmpty() throws Exception {
-        final List address = resources.client().target("/v1/connect/address").request().get(List.class);
+        final List address = resources.client().target("/v1/connection/address").request().get(List.class);
         Assert.assertNotNull(address);
     }
 
     @Test
     public void testGetDnsEmpty() throws Exception {
-        final List dns = resources.client().target("/v1/connect/dns").request().get(List.class);
+        final List dns = resources.client().target("/v1/connection/dns").request().get(List.class);
         Assert.assertNotNull(dns);
     }
 }

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResourceTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResourceTest.java
@@ -1,0 +1,121 @@
+package com.mesosphere.dcos.cassandra.scheduler.resources;
+
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.io.Resources;
+import com.mesosphere.dcos.cassandra.common.config.ClusterTaskConfig;
+import com.mesosphere.dcos.cassandra.scheduler.config.*;
+import com.mesosphere.dcos.cassandra.scheduler.tasks.CassandraTasks;
+import io.dropwizard.configuration.ConfigurationFactory;
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
+import io.dropwizard.configuration.FileConfigurationSourceProvider;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.testing.junit.ResourceTestRule;
+import io.dropwizard.validation.BaseValidator;
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.retry.RetryForever;
+import org.apache.curator.retry.RetryUntilElapsed;
+import org.apache.curator.test.TestingServer;
+import org.apache.mesos.curator.CuratorStateStore;
+import org.apache.mesos.state.StateStore;
+import org.junit.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class ConnectionResourceTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+            ConnectionResourceTest.class);
+    private static TestingServer server;
+
+    private static CassandraSchedulerConfiguration config;
+
+    private static DefaultConfigurationManager configurationManager;
+
+    private static CassandraTasks cassandraTasks;
+    private static ConfigurationManager configuration;
+
+    @Rule
+    public final ResourceTestRule resources = ResourceTestRule.builder()
+            .addResource(new ConnectionResource(cassandraTasks, configuration)).build();
+
+    @BeforeClass
+    public static void beforeAll() throws Exception {
+        server = new TestingServer();
+        server.start();
+        final ConfigurationFactory<MutableSchedulerConfiguration> factory =
+                new ConfigurationFactory<>(
+                        MutableSchedulerConfiguration.class,
+                        BaseValidator.newValidator(),
+                        Jackson.newObjectMapper().registerModule(
+                                new GuavaModule())
+                                .registerModule(new Jdk8Module()),
+                        "dw");
+        MutableSchedulerConfiguration mutable = factory.build(
+                new SubstitutingSourceProvider(
+                        new FileConfigurationSourceProvider(),
+                        new EnvironmentVariableSubstitutor(false, true)),
+                Resources.getResource("scheduler.yml").getFile());
+        config = mutable.createConfig();
+
+        final CuratorFrameworkConfig curatorConfig = mutable.getCuratorConfig();
+        RetryPolicy retryPolicy =
+                (curatorConfig.getOperationTimeout().isPresent()) ?
+                        new RetryUntilElapsed(
+                                curatorConfig.getOperationTimeoutMs()
+                                        .get()
+                                        .intValue()
+                                , (int) curatorConfig.getBackoffMs()) :
+                        new RetryForever((int) curatorConfig.getBackoffMs());
+
+        StateStore stateStore = new CuratorStateStore(
+                config.getServiceConfig().getName(),
+                server.getConnectString(),
+                retryPolicy);
+        configurationManager =
+                new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
+                        config.getServiceConfig().getName(),
+                        server.getConnectString(),
+                        config,
+                        new ConfigValidator(),
+                        stateStore);
+        config = (CassandraSchedulerConfiguration) configurationManager.getTargetConfig();
+        configuration = new ConfigurationManager(configurationManager);
+        ClusterTaskConfig clusterTaskConfig = config.getClusterTaskConfig();
+        cassandraTasks = new CassandraTasks(
+                configuration,
+                curatorConfig,
+                clusterTaskConfig,
+                stateStore);
+    }
+
+    @AfterClass
+    public static void afterAll() throws Exception {
+        server.close();
+        server.stop();
+    }
+
+    @Test
+    public void testGetConnectEmpty() throws Exception {
+        final Map map = resources.client().target("/v1/connect").request().get(Map.class);
+        final Object address = map.get("address");
+        final Object dns = map.get("dns");
+        Assert.assertNotNull(address);
+        Assert.assertNotNull(dns);
+    }
+
+    @Test
+    public void testGetAddressEmpty() throws Exception {
+        final List address = resources.client().target("/v1/connect/address").request().get(List.class);
+        Assert.assertNotNull(address);
+    }
+
+    @Test
+    public void testGetDnsEmpty() throws Exception {
+        final List dns = resources.client().target("/v1/connect/dns").request().get(List.class);
+        Assert.assertNotNull(dns);
+    }
+}

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResourceTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResourceTest.java
@@ -20,15 +20,11 @@ import org.apache.curator.test.TestingServer;
 import org.apache.mesos.curator.CuratorStateStore;
 import org.apache.mesos.state.StateStore;
 import org.junit.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
 
 public class ConnectionResourceTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(
-            ConnectionResourceTest.class);
     private static TestingServer server;
 
     private static CassandraSchedulerConfiguration config;

--- a/cli/dcos-cassandra/main.go
+++ b/cli/dcos-cassandra/main.go
@@ -65,11 +65,11 @@ type ConnectionHandler struct {
 }
 func (cmd *ConnectionHandler) runBase(c *kingpin.ParseContext) error {
 	if cmd.showAddress {
-		cli.PrintJSON(cli.HTTPGet("v1/connect/address"))
+		cli.PrintJSON(cli.HTTPGet("v1/connection/address"))
 	} else if cmd.showDns {
-		cli.PrintJSON(cli.HTTPGet("v1/connect/dns"))
+		cli.PrintJSON(cli.HTTPGet("v1/connection/dns"))
 	} else {
-		cli.PrintJSON(cli.HTTPGet("v1/connect"))
+		cli.PrintJSON(cli.HTTPGet("v1/connection"))
 	}
 	return nil
 }

--- a/cli/dcos-cassandra/main.go
+++ b/cli/dcos-cassandra/main.go
@@ -65,11 +65,11 @@ type ConnectionHandler struct {
 }
 func (cmd *ConnectionHandler) runBase(c *kingpin.ParseContext) error {
 	if cmd.showAddress {
-		cli.PrintJSON(cli.HTTPGet("v1/nodes/connect/address"))
+		cli.PrintJSON(cli.HTTPGet("v1/connect/address"))
 	} else if cmd.showDns {
-		cli.PrintJSON(cli.HTTPGet("v1/nodes/connect/dns"))
+		cli.PrintJSON(cli.HTTPGet("v1/connect/dns"))
 	} else {
-		cli.PrintJSON(cli.HTTPGet("v1/nodes/connect"))
+		cli.PrintJSON(cli.HTTPGet("v1/connect"))
 	}
 	return nil
 }

--- a/integration/tests/defaults.py
+++ b/integration/tests/defaults.py
@@ -5,6 +5,8 @@ DEFAULT_NODE_COUNT = 3
 PACKAGE_NAME = 'cassandra'
 TASK_RUNNING_STATE = 'TASK_RUNNING'
 
+ACS_TOKEN = shakedown.run_dcos_command('config show core.dcos_acs_token')[0].strip()
+DCOS_URL = shakedown.run_dcos_command('config show core.dcos_url')[0].strip()
 
 _request_headers = None
 def request_headers():

--- a/integration/tests/test_sanity.py
+++ b/integration/tests/test_sanity.py
@@ -25,7 +25,7 @@ def install_framework():
 
 
 def test_connect(install_framework):
-    result = requests.get(cassandra_api_url('connect'), headers=request_headers())
+    result = requests.get(cassandra_api_url('connection'), headers=request_headers())
 
     try:
         body = result.json()
@@ -38,7 +38,7 @@ def test_connect(install_framework):
 
 
 def test_connect_address(install_framework):
-    result = requests.get(cassandra_api_url('connect/address'), headers=request_headers())
+    result = requests.get(cassandra_api_url('connection/address'), headers=request_headers())
 
     try:
         body = result.json()
@@ -49,7 +49,7 @@ def test_connect_address(install_framework):
 
 
 def test_connect_dns(install_framework):
-    result = requests.get(cassandra_api_url('connect/dns'), headers=request_headers())
+    result = requests.get(cassandra_api_url('connection/dns'), headers=request_headers())
 
     try:
         body = result.json()

--- a/integration/tests/test_sanity.py
+++ b/integration/tests/test_sanity.py
@@ -1,0 +1,59 @@
+import json
+import pytest
+import requests
+import shakedown
+from tests.command import (
+    cassandra_api_url,
+    check_health,
+    get_cassandra_config,
+    marathon_api_url,
+    request,
+    spin,
+    uninstall
+)
+from tests.defaults import DEFAULT_NODE_COUNT, PACKAGE_NAME, request_headers
+
+
+@pytest.yield_fixture
+def install_framework():
+    shakedown.install_package_and_wait(PACKAGE_NAME)
+    check_health()
+
+    yield
+
+    uninstall()
+
+
+def test_connect(install_framework):
+    result = requests.get(cassandra_api_url('connect'), headers=request_headers())
+
+    try:
+        body = result.json()
+        assert len(body) == 2
+        assert len(body["address"]) == DEFAULT_NODE_COUNT
+        assert len(body["dns"]) == DEFAULT_NODE_COUNT
+    except json.decoder.JSONDecodeError:
+        print('Failed to parse connect response')
+        return False
+
+
+def test_connect_address(install_framework):
+    result = requests.get(cassandra_api_url('connect/address'), headers=request_headers())
+
+    try:
+        body = result.json()
+        assert len(body) == DEFAULT_NODE_COUNT
+    except json.decoder.JSONDecodeError:
+        print('Failed to parse connect response')
+        return False
+
+
+def test_connect_dns(install_framework):
+    result = requests.get(cassandra_api_url('connect/dns'), headers=request_headers())
+
+    try:
+        body = result.json()
+        assert len(body) == DEFAULT_NODE_COUNT
+    except json.decoder.JSONDecodeError:
+        print('Failed to parse connect response')
+        return False


### PR DESCRIPTION
To ensure API consistency across DC/OS services we want to ensure that our APIs look and behave similarly.

This PR deprecates `/v1/nodes/connect` and introduces `/v1/connection` endpoint. The new endpoints offers feature parity w.r.t. the old endpoint.

Here's how the deprecation cycle looks like:
- `DC/OS 1.8`: Deprecated API works via: `/v1/nodes/connect`
- `DC/OS 1.10`: Requests to `/v1/nodes/connect` are redirected to: `/v1/connection`
- `DC/OS 1.11`: Deprecated `/v1/nodes/connect` API is removed and only `/v1/connection` API is supported onwards.
