### PR TITLE
Implement named VIP support, with some refactoring to make it fit

### DIFF
--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraDaemonTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraDaemonTask.java
@@ -15,10 +15,14 @@
  */
 package com.mesosphere.dcos.cassandra.common.tasks;
 
+import com.google.inject.Inject;
 import com.mesosphere.dcos.cassandra.common.config.CassandraConfig;
 import com.mesosphere.dcos.cassandra.common.util.TaskUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.DiscoveryInfo;
+import org.apache.mesos.Protos.Port;
+import org.apache.mesos.dcos.Capabilities;
 import org.apache.mesos.offer.VolumeRequirement;
 import org.apache.mesos.protobuf.LabelBuilder;
 import org.slf4j.Logger;
@@ -28,6 +32,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import javax.annotation.Nullable;
 
 /**
  * CassandraDaemonTask extends CassandraTask to implement the task for a
@@ -40,22 +46,83 @@ import java.util.UUID;
 public class CassandraDaemonTask extends CassandraTask {
     private static final Logger LOGGER =
             LoggerFactory.getLogger(CassandraDaemonTask.class);
+
     /**
      * String prefix for the CassandraDaemon task.
      */
     public static final String NAME_PREFIX = "node-";
+
+    /**
+     * Public node name used in VIP
+     */
+    public static final String VIP_NODE_NAME = "node";
+
+    /**
+     * Public port used in VIP
+     */
+    public static final int VIP_NODE_PORT = 9042; // cassandra's default native transport port
 
 
     public static CassandraDaemonTask parse(final Protos.TaskInfo info) {
         return new CassandraDaemonTask(info);
     }
 
-    public static CassandraDaemonTask create(
-        final String name,
-        final String configName,
-        final CassandraTaskExecutor executor,
-        final CassandraConfig config) {
-        return new CassandraDaemonTask(name, configName, executor, config);
+    /**
+     * Factory for {@link CassandraDaemonTask}s.
+     */
+    public static class Factory {
+
+        private final Capabilities capabilities;
+
+        @Inject
+        public Factory(Capabilities capabilities) {
+            this.capabilities = capabilities;
+        }
+
+        public CassandraDaemonTask create(
+                final String name,
+                final String configName,
+                final CassandraTaskExecutor executor,
+                final CassandraConfig config) {
+            return new CassandraDaemonTask(name, configName, executor, config, capabilities);
+        }
+
+        public CassandraDaemonTask move(
+                CassandraDaemonTask currentDaemon, CassandraTaskExecutor executor) {
+            final List<Protos.Label> labelsList =
+                    currentDaemon.getTaskInfo().getLabels().getLabelsList();
+            String configName = "";
+            for (Protos.Label label : labelsList) {
+                if ("config_target".equals(label.getKey())) {
+                    configName = label.getValue();
+                }
+            }
+            if (StringUtils.isBlank(configName)) {
+                throw new IllegalStateException("Task should have 'config_target'");
+            }
+            CassandraDaemonTask replacementDaemon = new CassandraDaemonTask(
+                    currentDaemon.getName(),
+                    configName,
+                    executor,
+                    currentDaemon.getConfig(),
+                    capabilities,
+                    currentDaemon.getData().replacing(currentDaemon.getData().getHostname()));
+
+            Protos.TaskInfo taskInfo = Protos.TaskInfo.newBuilder(replacementDaemon.getTaskInfo())
+                    .setTaskId(currentDaemon.getTaskInfo().getTaskId())
+                    .build();
+
+            return new CassandraDaemonTask(taskInfo);
+        }
+
+        public CassandraDaemonTask create(
+                final String name,
+                final String configName,
+                final CassandraTaskExecutor executor,
+                final CassandraConfig config,
+                final CassandraData data) {
+            return new CassandraDaemonTask(name, configName, executor, config, capabilities, data);
+        }
     }
 
     private static CassandraConfig updateConfig(
@@ -75,13 +142,13 @@ public class CassandraDaemonTask extends CassandraTask {
      * @param executor The exeuctor for the CassandraDaemonTask.
      * @param config   The configuration for the Cassandra node.
      */
-    protected CassandraDaemonTask(
+    private CassandraDaemonTask(
         final String name,
         final String configName,
         final CassandraTaskExecutor executor,
         final CassandraConfig config,
+        final Capabilities capabilities,
         final CassandraData data) {
-
         super(
             name,
             configName,
@@ -96,26 +163,29 @@ public class CassandraDaemonTask extends CassandraTask {
                 config.getApplication().getSslStoragePort(),
                 config.getApplication().getRpcPort(),
                 config.getApplication().getNativeTransportPort()),
+            getDiscoveryInfo(capabilities, name, config.getApplication().getNativeTransportPort()),
             data);
     }
 
-    protected CassandraDaemonTask(
+    private CassandraDaemonTask(
             final String name,
             final String configName,
             final CassandraTaskExecutor executor,
-            final CassandraConfig config) {
+            final CassandraConfig config,
+            final Capabilities capabilities) {
         this(
             name,
             configName,
             executor,
             config,
+            capabilities,
             CassandraData.createDaemonData(
                 "",
                 CassandraMode.STARTING,
                 config));
     }
 
-    protected CassandraDaemonTask(final Protos.TaskInfo info) {
+    private CassandraDaemonTask(final Protos.TaskInfo info) {
         super(info);
     }
 
@@ -211,31 +281,6 @@ public class CassandraDaemonTask extends CassandraTask {
             .setLabels(Protos.Labels.newBuilder().addLabels(label).build()).build());
     }
 
-    public CassandraDaemonTask move(CassandraTaskExecutor executor) {
-        final List<Protos.Label> labelsList = getTaskInfo().getLabels().getLabelsList();
-        String configName = "";
-        for (Protos.Label label : labelsList) {
-            if ("config_target".equals(label.getKey())) {
-                configName = label.getValue();
-            }
-        }
-        if (StringUtils.isBlank(configName)) {
-            throw new IllegalStateException("Task should have 'config_target'");
-        }
-        CassandraDaemonTask replacementDaemon = new CassandraDaemonTask(
-            getName(),
-            configName,
-            executor,
-            getConfig(),
-            getData().replacing(getData().getHostname()));
-
-        Protos.TaskInfo taskInfo = Protos.TaskInfo.newBuilder(replacementDaemon.getTaskInfo())
-                .setTaskId(getTaskInfo().getTaskId())
-                .build();
-
-        return new CassandraDaemonTask(taskInfo);
-    }
-
     @Override
     public CassandraDaemonTask updateId() {
         return new CassandraDaemonTask(getBuilder()
@@ -246,5 +291,26 @@ public class CassandraDaemonTask extends CassandraTask {
             .build());
     }
 
-
+    @Nullable
+    private static DiscoveryInfo getDiscoveryInfo(
+            Capabilities capabilities, String nodeName, int nativePort) {
+        try {
+            if (!capabilities.supportsNamedVips()) {
+                return null;
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Unable to determine Named VIP support, assuming they are unavailable.", e);
+            return null;
+        }
+        DiscoveryInfo.Builder discoveryBuilder = DiscoveryInfo.newBuilder()
+            .setVisibility(DiscoveryInfo.Visibility.EXTERNAL)
+            .setName(nodeName);
+        Port.Builder portBuilder = discoveryBuilder.getPortsBuilder().addPortsBuilder()
+            .setNumber(nativePort)
+            .setProtocol("tcp");
+        portBuilder.getLabelsBuilder().addLabelsBuilder()
+            .setKey("VIP_" + UUID.randomUUID())
+            .setValue(String.format("%s:%d", VIP_NODE_NAME, VIP_NODE_PORT));
+        return discoveryBuilder.build();
+    }
 }

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraTask.java
@@ -15,8 +15,6 @@
  */
 package com.mesosphere.dcos.cassandra.common.tasks;
 
-import com.google.inject.Inject;
-
 import com.google.protobuf.TextFormat;
 import com.mesosphere.dcos.cassandra.common.config.CassandraConfig;
 import org.apache.mesos.offer.VolumeRequirement;
@@ -32,7 +30,10 @@ import com.mesosphere.dcos.cassandra.common.tasks.repair.RepairTask;
 import java.io.IOException;
 import java.util.*;
 
+import javax.annotation.Nullable;
+
 import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.DiscoveryInfo;
 import org.apache.mesos.offer.ResourceUtils;
 import org.apache.mesos.offer.TaskUtils;
 import org.apache.mesos.protobuf.LabelBuilder;
@@ -186,7 +187,6 @@ public abstract class CassandraTask {
     }
 
 
-    @Inject
     protected CassandraTask(
         final String name,
         final String configName,
@@ -197,6 +197,7 @@ public abstract class CassandraTask {
         final VolumeRequirement.VolumeMode volumeMode,
         final VolumeRequirement.VolumeType volumeType,
         final Collection<Integer> ports,
+        @Nullable final DiscoveryInfo discoveryInfo,
         final CassandraData data) {
 
         String role = executor.getRole();
@@ -224,6 +225,10 @@ public abstract class CassandraTask {
 
         if (!ports.isEmpty()) {
             builder.addResources(ResourceUtils.getDesiredRanges(role, principal, "ports", Algorithms.createRanges(ports)));
+        }
+
+        if (discoveryInfo != null) {
+            builder.setDiscovery(discoveryInfo);
         }
 
         info = builder.build();

--- a/cassandra-commons/src/test/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraDaemonTaskTest.java
+++ b/cassandra-commons/src/test/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraDaemonTaskTest.java
@@ -2,16 +2,21 @@ package com.mesosphere.dcos.cassandra.common.tasks;
 
 import com.mesosphere.dcos.cassandra.common.config.*;
 import org.apache.mesos.Protos;
+import org.apache.mesos.dcos.Capabilities;
 import org.apache.mesos.offer.VolumeRequirement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+
+import static org.mockito.Mockito.when;
 
 /**
  * This class tests the CassandraDaemonTask class.
@@ -21,11 +26,15 @@ public class CassandraDaemonTaskTest {
     private static final UUID TEST_CONFIG_ID = UUID.randomUUID();
     public static final String TEST_CONFIG_NAME = TEST_CONFIG_ID.toString();
 
+    private CassandraDaemonTask.Factory testTaskFactory;
     private ExecutorConfig testExecutorConfig;
     private CassandraTaskExecutor testTaskExecutor;
 
     @Before
-    public void beforeEach() throws URISyntaxException {
+    public void beforeEach() throws URISyntaxException, IOException {
+        Capabilities mockCapabilities = Mockito.mock(Capabilities.class);
+        when(mockCapabilities.supportsNamedVips()).thenReturn(true);
+        testTaskFactory = new CassandraDaemonTask.Factory(mockCapabilities);
         testExecutorConfig = ExecutorConfig.create(
                 "test-cmd",
                 Arrays.asList("arg0"),
@@ -40,7 +49,7 @@ public class CassandraDaemonTaskTest {
 
         testTaskExecutor = CassandraTaskExecutor.create(
                 "test-framework-id",
-          TEST_DAEMON_NAME,
+                TEST_DAEMON_NAME,
                 "test-role",
                 "test-principal",
                 testExecutorConfig);
@@ -48,7 +57,7 @@ public class CassandraDaemonTaskTest {
 
     @Test
     public void testConstructCassandraDaemonTask() {
-        Assert.assertNotNull(CassandraDaemonTask.create(
+        Assert.assertNotNull(testTaskFactory.create(
           TEST_DAEMON_NAME,
           TEST_CONFIG_NAME,
                 testTaskExecutor,
@@ -57,7 +66,7 @@ public class CassandraDaemonTaskTest {
 
     @Test
     public void testUpdateUnchangedConfig() {
-        CassandraDaemonTask daemonTask = CassandraDaemonTask.create(
+        CassandraDaemonTask daemonTask = testTaskFactory.create(
           TEST_DAEMON_NAME,
           TEST_CONFIG_NAME,
                 testTaskExecutor,
@@ -69,7 +78,7 @@ public class CassandraDaemonTaskTest {
 
     @Test
     public void testUpdateCpuConfig() {
-        CassandraDaemonTask daemonTask = CassandraDaemonTask.create(
+        CassandraDaemonTask daemonTask = testTaskFactory.create(
           TEST_DAEMON_NAME,
           TEST_CONFIG_NAME,
                 testTaskExecutor,
@@ -95,7 +104,7 @@ public class CassandraDaemonTaskTest {
 
     @Test
     public void testUpdateMemConfig() {
-        CassandraDaemonTask daemonTask = CassandraDaemonTask.create(
+        CassandraDaemonTask daemonTask = testTaskFactory.create(
           TEST_DAEMON_NAME,
           TEST_CONFIG_NAME,
                 testTaskExecutor,
@@ -123,7 +132,7 @@ public class CassandraDaemonTaskTest {
 
     @Test
     public void testUpdateDiskConfig() {
-        CassandraDaemonTask daemonTask = CassandraDaemonTask.create(
+        CassandraDaemonTask daemonTask = testTaskFactory.create(
           TEST_DAEMON_NAME,
           TEST_CONFIG_NAME,
                 testTaskExecutor,

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/SchedulerModule.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/SchedulerModule.java
@@ -36,12 +36,15 @@ import org.apache.curator.retry.RetryUntilElapsed;
 import org.apache.http.client.HttpClient;
 import org.apache.mesos.config.ConfigStoreException;
 import org.apache.mesos.curator.CuratorStateStore;
+import org.apache.mesos.dcos.Capabilities;
+import org.apache.mesos.dcos.DcosCluster;
 import org.apache.mesos.reconciliation.DefaultReconciler;
 import org.apache.mesos.reconciliation.Reconciler;
 import org.apache.mesos.scheduler.plan.PhaseStrategyFactory;
 import org.apache.mesos.scheduler.plan.StageManager;
 import org.apache.mesos.state.StateStore;
 
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -87,6 +90,13 @@ public class SchedulerModule extends AbstractModule {
                 curatorConfig.getServers(),
                 retryPolicy);
         bind(StateStore.class).toInstance(curatorStateStore);
+
+        try {
+            Capabilities capabilities = new Capabilities(new DcosCluster());
+            bind(Capabilities.class).toInstance(capabilities);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
 
         try {
             final ConfigValidator configValidator = new ConfigValidator();

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/ConfigurationManager.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/ConfigurationManager.java
@@ -17,14 +17,16 @@ import java.util.Optional;
 import java.util.UUID;
 
 public class ConfigurationManager implements Managed {
-    private static final Logger LOGGER =
-        LoggerFactory.getLogger(ConfigurationManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationManager.class);
 
+    private final CassandraDaemonTask.Factory cassandraDaemonTaskFactory;
     private final DefaultConfigurationManager configurationManager;
 
     @Inject
     public ConfigurationManager(
-        DefaultConfigurationManager configurationManager) {
+            CassandraDaemonTask.Factory cassandraDaemonTaskFactory,
+            DefaultConfigurationManager configurationManager) {
+        this.cassandraDaemonTaskFactory = cassandraDaemonTaskFactory;
         this.configurationManager = configurationManager;
     }
 
@@ -48,7 +50,7 @@ public class ConfigurationManager implements Managed {
                                             String configName) throws ConfigStoreException {
         final CassandraSchedulerConfiguration targetConfig = getTargetConfig();
         final CassandraConfig cassandraConfig = targetConfig.getCassandraConfig();
-        return CassandraDaemonTask.create(
+        return cassandraDaemonTaskFactory.create(
             name,
             configName,
             createExecutor(frameworkId, name + "_executor", role, principal),
@@ -61,7 +63,7 @@ public class ConfigurationManager implements Managed {
             String role,
             String principal) throws ConfigStoreException {
         CassandraTaskExecutor executor = createExecutor(frameworkId, daemonTask.getName() + "_executor", role, principal);
-        return daemonTask.move(executor);
+        return cassandraDaemonTaskFactory.move(daemonTask, executor);
     }
 
     public CassandraDaemonTask replaceDaemon(CassandraDaemonTask task) {

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResource.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResource.java
@@ -1,19 +1,21 @@
 package com.mesosphere.dcos.cassandra.scheduler.resources;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.mesosphere.dcos.cassandra.common.tasks.CassandraDaemonTask;
 import com.mesosphere.dcos.cassandra.scheduler.config.ConfigurationManager;
 import com.mesosphere.dcos.cassandra.scheduler.config.ServiceConfig;
 import com.mesosphere.dcos.cassandra.scheduler.tasks.CassandraTasks;
+
 import org.apache.mesos.Protos;
 import org.apache.mesos.config.ConfigStoreException;
+import org.apache.mesos.dcos.Capabilities;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -21,64 +23,82 @@ import java.util.stream.Collectors;
 @Path("/v1/connection")
 @Produces(MediaType.APPLICATION_JSON)
 public class ConnectionResource {
+    private final Capabilities capabilities;
     private final CassandraTasks tasks;
     private final ConfigurationManager configurationManager;
 
     @Inject
-    public ConnectionResource(final CassandraTasks tasks,
-                              final ConfigurationManager configurationManager) {
+    public ConnectionResource(
+            final Capabilities capabilities,
+            final CassandraTasks tasks,
+            final ConfigurationManager configurationManager) {
+        this.capabilities = capabilities;
         this.tasks = tasks;
         this.configurationManager = configurationManager;
     }
 
     @GET
-    public Map<String, List<String>> connect() throws ConfigStoreException {
-        return ImmutableMap.of("address", getRunningAddresses(),
-                "dns", getRunningDns());
+    public Map<String, Object> connect() throws ConfigStoreException {
+        ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+        builder.put("address", connectAddress());
+        builder.put("dns", connectDns());
+        try {
+            if (capabilities.supportsNamedVips()) {
+                builder.put("vip", toVip(configurationManager.getTargetConfig().getServiceConfig()));
+            }
+        } catch (Exception e) {
+            // assume unavailable
+        }
+        return builder.build();
     }
 
     @GET
     @Path("/address")
     public List<String> connectAddress() {
-        return getRunningAddresses();
+        return toRunningAddresses(tasks.getDaemons());
     }
 
     @GET
     @Path("/dns")
     public List<String> connectDns() throws ConfigStoreException {
-        return getRunningDns();
+        return toRunningDns(
+                tasks.getDaemons(), configurationManager.getTargetConfig().getServiceConfig());
     }
 
-    @VisibleForTesting
-    protected List<String> getRunningAddresses() {
-        return getRunningDeamons().stream().map(daemonTask ->
-                daemonTask.getHostname() +
-                        ":" +
-                        daemonTask.getConfig()
-                                .getApplication()
-                                .getNativeTransportPort())
+    private List<String> toRunningAddresses(
+            final Map<String, CassandraDaemonTask> daemons) {
+        return toRunningDaemons(daemons).stream()
+                .map(daemonTask -> String.format(
+                        "%s:%d",
+                        daemonTask.getHostname(),
+                        daemonTask.getConfig().getApplication().getNativeTransportPort()))
                 .collect(Collectors.toList());
     }
 
-    @VisibleForTesting
-    protected List<String> getRunningDns() throws ConfigStoreException {
-        final ServiceConfig serviceConfig = configurationManager.getTargetConfig().getServiceConfig();
-        return getRunningDeamons().stream().map(daemonTask ->
-                daemonTask.getName() +
-                        "." + serviceConfig.getName() + ".mesos:" +
-                        daemonTask.getConfig()
-                                .getApplication()
-                                .getNativeTransportPort()
-        ).collect(Collectors.toList());
+    private static List<String> toRunningDns(
+            final Map<String, CassandraDaemonTask> daemons,
+            final ServiceConfig serviceConfig) {
+        return toRunningDaemons(daemons).stream()
+                .map(daemonTask -> String.format(
+                        "%s.%s.mesos:%d",
+                        daemonTask.getName(),
+                        serviceConfig.getName(),
+                        daemonTask.getConfig().getApplication().getNativeTransportPort()))
+                .collect(Collectors.toList());
     }
 
-    @VisibleForTesting
-    protected List<CassandraDaemonTask> getRunningDeamons() {
-        return tasks.getDaemons().values().stream()
-                .filter
-                        (daemonTask ->
-                                Protos.TaskState.TASK_RUNNING.equals(
-                                        daemonTask.getState())).collect
-                        (Collectors.toList());
+    private static String toVip(ServiceConfig serviceConfig) {
+        return String.format(
+                "%s.%s.l4lb.thisdcos.directory:%d",
+                CassandraDaemonTask.VIP_NODE_NAME,
+                serviceConfig.getName(),
+                CassandraDaemonTask.VIP_NODE_PORT);
+    }
+
+    private static List<CassandraDaemonTask> toRunningDaemons(
+            final Map<String, CassandraDaemonTask> daemons) {
+        return daemons.values().stream()
+                .filter(daemonTask -> Protos.TaskState.TASK_RUNNING.equals(daemonTask.getState()))
+                .collect(Collectors.toList());
     }
 }

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/TasksResource.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/TasksResource.java
@@ -16,7 +16,6 @@
 
 package com.mesosphere.dcos.cassandra.scheduler.resources;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.protobuf.TextFormat;
 import com.mesosphere.dcos.cassandra.common.tasks.CassandraContainer;
@@ -25,6 +24,7 @@ import com.mesosphere.dcos.cassandra.scheduler.client.SchedulerClient;
 import com.mesosphere.dcos.cassandra.scheduler.config.ConfigurationManager;
 import com.mesosphere.dcos.cassandra.scheduler.tasks.CassandraTasks;
 import org.apache.mesos.config.ConfigStoreException;
+import org.apache.mesos.dcos.Capabilities;
 import org.glassfish.jersey.server.ManagedAsync;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,14 +44,18 @@ import java.util.Optional;
 public class TasksResource {
     private static final Logger LOGGER = LoggerFactory.getLogger
             (TasksResource.class);
+    private final Capabilities capabilities;
     private final CassandraTasks tasks;
     private final SchedulerClient client;
     private final ConfigurationManager configurationManager;
 
     @Inject
-    public TasksResource(final CassandraTasks tasks,
-                         final SchedulerClient client,
-                         final ConfigurationManager configurationManager) {
+    public TasksResource(
+            final Capabilities capabilities,
+            final CassandraTasks tasks,
+            final SchedulerClient client,
+            final ConfigurationManager configurationManager) {
+        this.capabilities = capabilities;
         this.tasks = tasks;
         this.client = client;
         this.configurationManager = configurationManager;
@@ -141,8 +145,9 @@ public class TasksResource {
     @GET
     @Path("connect")
     @Deprecated
-    public Map<String, List<String>> connect() throws ConfigStoreException {
-        final ConnectionResource connectionResource = new ConnectionResource(tasks, configurationManager);
+    public Map<String, Object> connect() throws ConfigStoreException {
+        final ConnectionResource connectionResource =
+                new ConnectionResource(capabilities, tasks, configurationManager);
         return connectionResource.connect();
     }
 
@@ -153,7 +158,8 @@ public class TasksResource {
     @Path("connect/address")
     @Deprecated
     public List<String> connectAddress() {
-        final ConnectionResource connectionResource = new ConnectionResource(tasks, configurationManager);
+        final ConnectionResource connectionResource =
+                new ConnectionResource(capabilities, tasks, configurationManager);
         return connectionResource.connectAddress();
     }
 
@@ -164,7 +170,8 @@ public class TasksResource {
     @Path("connect/dns")
     @Deprecated
     public List<String> connectDns() throws ConfigStoreException {
-        final ConnectionResource connectionResource = new ConnectionResource(tasks, configurationManager);
+        final ConnectionResource connectionResource =
+                new ConnectionResource(capabilities, tasks, configurationManager);
         return connectionResource.connectDns();
     }
 }

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/CassandraSchedulerTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/CassandraSchedulerTest.java
@@ -31,6 +31,7 @@ import org.apache.mesos.Protos;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
 import org.apache.mesos.curator.CuratorStateStore;
+import org.apache.mesos.dcos.Capabilities;
 import org.apache.mesos.reconciliation.DefaultReconciler;
 import org.apache.mesos.reconciliation.Reconciler;
 import org.apache.mesos.scheduler.plan.Block;
@@ -42,7 +43,9 @@ import org.apache.mesos.testing.QueuedSchedulerDriver;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -55,8 +58,12 @@ import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
 
 public class CassandraSchedulerTest {
+    @Mock private CompletionStage<Boolean> mockStage;
+    @Mock private CompletableFuture<Boolean> mockFuture;
+
     private CassandraScheduler scheduler;
     private ConfigurationManager configurationManager;
     private StageManager stageManager;
@@ -88,14 +95,13 @@ public class CassandraSchedulerTest {
     }
 
     public void beforeHelper(String configName) throws Exception {
+        MockitoAnnotations.initMocks(this);
         mesosConfig = Mockito.mock(MesosConfig.class);
 
         client = Mockito.mock(SchedulerClient.class);
-        CompletionStage<Boolean> csb = Mockito.mock(CompletionStage.class);
-        CompletableFuture<Boolean> cfb = Mockito.mock(CompletableFuture.class);
-        Mockito.when(cfb.get()).thenReturn(true);
-        Mockito.when(csb.toCompletableFuture()).thenReturn(cfb);
-        Mockito.when(client.shutdown(Mockito.anyString(), Mockito.anyInt())).thenReturn(csb);
+        Mockito.when(mockFuture.get()).thenReturn(true);
+        Mockito.when(mockStage.toCompletableFuture()).thenReturn(mockFuture);
+        Mockito.when(client.shutdown(Mockito.anyString(), Mockito.anyInt())).thenReturn(mockStage);
         backup = Mockito.mock(BackupManager.class);
         restore = Mockito.mock(RestoreManager.class);
         cleanup = Mockito.mock(CleanupManager.class);
@@ -138,7 +144,12 @@ public class CassandraSchedulerTest {
                 new ConfigValidator(),
                 stateStore);
 
-        configurationManager = new ConfigurationManager(defaultConfigurationManager);
+
+        Capabilities mockCapabilities = Mockito.mock(Capabilities.class);
+        when(mockCapabilities.supportsNamedVips()).thenReturn(true);
+        configurationManager = new ConfigurationManager(
+                new CassandraDaemonTask.Factory(mockCapabilities),
+                defaultConfigurationManager);
 
         final ClusterTaskConfig clusterTaskConfig = configurationManager.getTargetConfig().getClusterTaskConfig();
         cassandraTasks = new CassandraTasks(

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/config/ConfigurationManagerTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/config/ConfigurationManagerTest.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.io.Resources;
 import com.mesosphere.dcos.cassandra.common.config.ExecutorConfig;
+import com.mesosphere.dcos.cassandra.common.tasks.CassandraDaemonTask;
+
 import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.FileConfigurationSourceProvider;
@@ -16,27 +18,33 @@ import org.apache.curator.retry.RetryForever;
 import org.apache.curator.retry.RetryUntilElapsed;
 import org.apache.curator.test.TestingServer;
 import org.apache.mesos.curator.CuratorStateStore;
+import org.apache.mesos.dcos.Capabilities;
 import org.apache.mesos.state.StateStore;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.net.URI;
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 public class ConfigurationManagerTest {
     private static TestingServer server;
-    private static ConfigurationFactory<MutableSchedulerConfiguration> factory;
+    private static CassandraDaemonTask.Factory taskFactory;
+    private static ConfigurationFactory<MutableSchedulerConfiguration> configurationFactory;
     private static String connectString;
 
     @Before
     public void beforeAll() throws Exception {
         server = new TestingServer();
         server.start();
-        factory = new ConfigurationFactory<>(
+        Capabilities mockCapabilities = Mockito.mock(Capabilities.class);
+        when(mockCapabilities.supportsNamedVips()).thenReturn(true);
+        taskFactory = new CassandraDaemonTask.Factory(mockCapabilities);
+        configurationFactory = new ConfigurationFactory<>(
                         MutableSchedulerConfiguration.class,
                         BaseValidator.newValidator(),
                         Jackson.newObjectMapper()
@@ -55,7 +63,7 @@ public class ConfigurationManagerTest {
     @Test
     public void loadAndPersistConfiguration() throws Exception {
         final String configFilePath = Resources.getResource("scheduler.yml").getFile();
-        MutableSchedulerConfiguration mutableConfig = factory.build(
+        MutableSchedulerConfiguration mutableConfig = configurationFactory.build(
                 new SubstitutingSourceProvider(
                         new FileConfigurationSourceProvider(),
                         new EnvironmentVariableSubstitutor(false, true)),
@@ -82,7 +90,7 @@ public class ConfigurationManagerTest {
                 original,
                 new ConfigValidator(),
                 stateStore);
-        ConfigurationManager manager = new ConfigurationManager(configurationManager);
+        ConfigurationManager manager = new ConfigurationManager(taskFactory, configurationManager);
         CassandraSchedulerConfiguration targetConfig = (CassandraSchedulerConfiguration)configurationManager.getTargetConfig();
         assertEquals("cassandra", original.getServiceConfig().getName());
         assertEquals("cassandra-role", original.getServiceConfig().getRole());
@@ -102,7 +110,7 @@ public class ConfigurationManagerTest {
 
     @Test
     public void applyConfigUpdate() throws Exception {
-        MutableSchedulerConfiguration mutable = factory.build(
+        MutableSchedulerConfiguration mutable = configurationFactory.build(
                 new SubstitutingSourceProvider(
                         new FileConfigurationSourceProvider(),
                         new EnvironmentVariableSubstitutor(false, true)),
@@ -129,7 +137,7 @@ public class ConfigurationManagerTest {
                 original,
                 new ConfigValidator(),
                 stateStore);
-        ConfigurationManager manager = new ConfigurationManager(configurationManager);
+        ConfigurationManager manager = new ConfigurationManager(taskFactory, configurationManager);
         CassandraSchedulerConfiguration targetConfig =
           (CassandraSchedulerConfiguration)configurationManager.getTargetConfig();
 
@@ -155,7 +163,7 @@ public class ConfigurationManagerTest {
         int updatedServers = original.getServers() + 10;
         int updatedSeeds = original.getSeeds() + 5;
 
-        mutable = factory.build(
+        mutable = configurationFactory.build(
                 new SubstitutingSourceProvider(
                         new FileConfigurationSourceProvider(),
                         new EnvironmentVariableSubstitutor(false, true)),
@@ -180,7 +188,7 @@ public class ConfigurationManagerTest {
                 new ConfigValidator(),
                 stateStore);
         configurationManager.store(updated);
-        manager = new ConfigurationManager(configurationManager);
+        manager = new ConfigurationManager(taskFactory, configurationManager);
         targetConfig = (CassandraSchedulerConfiguration)configurationManager.getTargetConfig();
 
         manager.start();
@@ -196,7 +204,7 @@ public class ConfigurationManagerTest {
 
     @Test
     public void failOnBadServersCount() throws Exception {
-        MutableSchedulerConfiguration mutable = factory.build(
+        MutableSchedulerConfiguration mutable = configurationFactory.build(
                 new SubstitutingSourceProvider(
                         new FileConfigurationSourceProvider(),
                         new EnvironmentVariableSubstitutor(false, true)),
@@ -223,7 +231,7 @@ public class ConfigurationManagerTest {
                 originalConfig,
                 new ConfigValidator(),
                 stateStore);
-        ConfigurationManager manager = new ConfigurationManager(configurationManager);
+        ConfigurationManager manager = new ConfigurationManager(taskFactory, configurationManager);
         CassandraSchedulerConfiguration targetConfig = (CassandraSchedulerConfiguration)configurationManager.getTargetConfig();
 
         manager.start();
@@ -245,7 +253,7 @@ public class ConfigurationManagerTest {
                 mutable.createConfig(),
                 new ConfigValidator(),
                 stateStore);
-        manager = new ConfigurationManager(configurationManager);
+        manager = new ConfigurationManager(taskFactory, configurationManager);
 
         manager.start();
 
@@ -254,7 +262,7 @@ public class ConfigurationManagerTest {
 
     @Test
     public void failOnBadSeedsCount() throws Exception {
-        MutableSchedulerConfiguration mutableSchedulerConfiguration = factory.build(
+        MutableSchedulerConfiguration mutableSchedulerConfiguration = configurationFactory.build(
                 new SubstitutingSourceProvider(
                         new FileConfigurationSourceProvider(),
                         new EnvironmentVariableSubstitutor(false, true)),
@@ -281,7 +289,7 @@ public class ConfigurationManagerTest {
                 originalConfig,
                 new ConfigValidator(),
                 stateStore);
-        ConfigurationManager manager = new ConfigurationManager(configurationManager);
+        ConfigurationManager manager = new ConfigurationManager(taskFactory, configurationManager);
         CassandraSchedulerConfiguration targetConfig = (CassandraSchedulerConfiguration)configurationManager.getTargetConfig();
 
         manager.start();
@@ -303,7 +311,7 @@ public class ConfigurationManagerTest {
                 mutableSchedulerConfiguration.createConfig(),
                 new ConfigValidator(),
                 stateStore);
-        manager = new ConfigurationManager(configurationManager);
+        manager = new ConfigurationManager(taskFactory, configurationManager);
         manager.start();
         assertEquals(1, configurationManager.getErrors().size());
     }

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/offer/ClusterTaskOfferRequirementProviderTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/offer/ClusterTaskOfferRequirementProviderTest.java
@@ -19,11 +19,15 @@ import org.apache.curator.retry.RetryUntilElapsed;
 import org.apache.curator.test.TestingServer;
 import org.apache.mesos.Protos;
 import org.apache.mesos.curator.CuratorStateStore;
+import org.apache.mesos.dcos.Capabilities;
 import org.apache.mesos.offer.OfferRequirement;
 import org.apache.mesos.protobuf.ResourceBuilder;
 import org.apache.mesos.protobuf.TaskInfoBuilder;
 import org.apache.mesos.state.StateStore;
 import org.junit.*;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.List;
@@ -140,7 +144,11 @@ public class ClusterTaskOfferRequirementProviderTest {
                 config,
                 new ConfigValidator(),
                 stateStore);
-        configuration = new ConfigurationManager(configurationManager);
+        Capabilities mockCapabilities = Mockito.mock(Capabilities.class);
+        when(mockCapabilities.supportsNamedVips()).thenReturn(true);
+        configuration = new ConfigurationManager(
+                new CassandraDaemonTask.Factory(mockCapabilities),
+                configurationManager);
 
         provider = new ClusterTaskOfferRequirementProvider();
     }

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/cleanup/CleanupBlockTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/cleanup/CleanupBlockTest.java
@@ -12,7 +12,6 @@ import com.mesosphere.dcos.cassandra.scheduler.tasks.CassandraTasks;
 import org.apache.mesos.Protos;
 import org.apache.mesos.offer.OfferRequirement;
 import org.apache.mesos.offer.TaskUtils;
-import org.apache.mesos.scheduler.plan.Status;
 import org.apache.mesos.state.StateStore;
 import org.junit.Assert;
 import org.junit.Before;

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/repair/RepairBlockTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/repair/RepairBlockTest.java
@@ -12,7 +12,6 @@ import com.mesosphere.dcos.cassandra.scheduler.tasks.CassandraTasks;
 import org.apache.mesos.Protos;
 import org.apache.mesos.offer.OfferRequirement;
 import org.apache.mesos.offer.TaskUtils;
-import org.apache.mesos.scheduler.plan.Status;
 import org.apache.mesos.state.StateStore;
 import org.junit.Assert;
 import org.junit.Before;

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResourceTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/resources/ConnectionResourceTest.java
@@ -1,117 +1,137 @@
 package com.mesosphere.dcos.cassandra.scheduler.resources;
 
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.google.common.io.Resources;
-import com.mesosphere.dcos.cassandra.common.config.ClusterTaskConfig;
+import com.mesosphere.dcos.cassandra.common.config.CassandraApplicationConfig;
+import com.mesosphere.dcos.cassandra.common.config.CassandraConfig;
+import com.mesosphere.dcos.cassandra.common.tasks.CassandraDaemonTask;
 import com.mesosphere.dcos.cassandra.scheduler.config.*;
 import com.mesosphere.dcos.cassandra.scheduler.tasks.CassandraTasks;
-import io.dropwizard.configuration.ConfigurationFactory;
-import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
-import io.dropwizard.configuration.FileConfigurationSourceProvider;
-import io.dropwizard.configuration.SubstitutingSourceProvider;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.testing.junit.ResourceTestRule;
-import io.dropwizard.validation.BaseValidator;
-import org.apache.curator.RetryPolicy;
-import org.apache.curator.retry.RetryForever;
-import org.apache.curator.retry.RetryUntilElapsed;
-import org.apache.curator.test.TestingServer;
-import org.apache.mesos.curator.CuratorStateStore;
-import org.apache.mesos.state.StateStore;
+
+import org.apache.mesos.Protos.TaskState;
+import org.apache.mesos.dcos.Capabilities;
 import org.junit.*;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 public class ConnectionResourceTest {
-    private static TestingServer server;
+    private static final String TEST_SERVICE_NAME = "testService";
 
-    private static CassandraSchedulerConfiguration config;
-
-    private static DefaultConfigurationManager configurationManager;
-
-    private static CassandraTasks cassandraTasks;
-    private static ConfigurationManager configuration;
+    private static final CassandraDaemonTask TEST_TASK_1 = getMockTask("fooname", "foo.com", 1235);
+    private static final CassandraDaemonTask TEST_TASK_2 = getMockTask("barname", "bar.com", 1234);
+    private static final Map<String, CassandraDaemonTask> TEST_TASKS;
+    static {
+        TEST_TASKS = new TreeMap<>(); // keep consistent order
+        TEST_TASKS.put("foo", TEST_TASK_1);
+        TEST_TASKS.put("bar", TEST_TASK_2);
+    }
 
     @Rule
-    public final ResourceTestRule resources = ResourceTestRule.builder()
-            .addResource(new ConnectionResource(cassandraTasks, configuration)).build();
+    public final ResourceTestRule resourceWithVips = ResourceTestRule.builder()
+            .addResource(getConnectionResource(true)).build();
+    @Rule
+    public final ResourceTestRule resourceWithoutVips = ResourceTestRule.builder()
+            .addResource(getConnectionResource(false)).build();
 
-    @BeforeClass
-    public static void beforeAll() throws Exception {
-        server = new TestingServer();
-        server.start();
-        final ConfigurationFactory<MutableSchedulerConfiguration> factory =
-                new ConfigurationFactory<>(
-                        MutableSchedulerConfiguration.class,
-                        BaseValidator.newValidator(),
-                        Jackson.newObjectMapper().registerModule(
-                                new GuavaModule())
-                                .registerModule(new Jdk8Module()),
-                        "dw");
-        MutableSchedulerConfiguration mutable = factory.build(
-                new SubstitutingSourceProvider(
-                        new FileConfigurationSourceProvider(),
-                        new EnvironmentVariableSubstitutor(false, true)),
-                Resources.getResource("scheduler.yml").getFile());
-        config = mutable.createConfig();
-
-        final CuratorFrameworkConfig curatorConfig = mutable.getCuratorConfig();
-        RetryPolicy retryPolicy =
-                (curatorConfig.getOperationTimeout().isPresent()) ?
-                        new RetryUntilElapsed(
-                                curatorConfig.getOperationTimeoutMs()
-                                        .get()
-                                        .intValue()
-                                , (int) curatorConfig.getBackoffMs()) :
-                        new RetryForever((int) curatorConfig.getBackoffMs());
-
-        StateStore stateStore = new CuratorStateStore(
-                config.getServiceConfig().getName(),
-                server.getConnectString(),
-                retryPolicy);
-        configurationManager =
-                new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
-                        config.getServiceConfig().getName(),
-                        server.getConnectString(),
-                        config,
-                        new ConfigValidator(),
-                        stateStore);
-        config = (CassandraSchedulerConfiguration) configurationManager.getTargetConfig();
-        configuration = new ConfigurationManager(configurationManager);
-        ClusterTaskConfig clusterTaskConfig = config.getClusterTaskConfig();
-        cassandraTasks = new CassandraTasks(
-                configuration,
-                curatorConfig,
-                clusterTaskConfig,
-                stateStore);
-    }
-
-    @AfterClass
-    public static void afterAll() throws Exception {
-        server.close();
-        server.stop();
-    }
-
+    @SuppressWarnings("unchecked")
     @Test
-    public void testGetConnectEmpty() throws Exception {
-        final Map map = resources.client().target("/v1/connection").request().get(Map.class);
-        final Object address = map.get("address");
-        final Object dns = map.get("dns");
-        Assert.assertNotNull(address);
-        Assert.assertNotNull(dns);
+    public void testGetConnectWithVips() throws Exception {
+        final Map<String, Object> map = (Map<String, Object>) resourceWithVips.client()
+                .target("/v1/connection").request().get(Map.class);
+        assertEquals(3, map.size());
+
+        final List<String> address = (List<String>) map.get("address");
+        assertEquals(map.toString(), 2, address.size());
+        assertEquals("bar.com:1234", address.get(0));
+        assertEquals("foo.com:1235", address.get(1));
+
+        final List<String> dns = (List<String>) map.get("dns");
+        assertEquals(2, dns.size());
+        assertEquals("barname.testService.mesos:1234", dns.get(0));
+        assertEquals("fooname.testService.mesos:1235", dns.get(1));
+
+        String vip = map.get("vip").toString();
+        assertEquals("node.testService.l4lb.thisdcos.directory:9042", vip);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
-    public void testGetAddressEmpty() throws Exception {
-        final List address = resources.client().target("/v1/connection/address").request().get(List.class);
-        Assert.assertNotNull(address);
+    public void testGetConnectWithoutVips() throws Exception {
+        final Map<String, Object> map = (Map<String, Object>) resourceWithoutVips.client()
+                .target("/v1/connection").request().get(Map.class);
+        assertEquals(2, map.size());
+
+        final List<String> address = (List<String>) map.get("address");
+        assertEquals(2, address.size());
+        assertEquals("bar.com:1234", address.get(0));
+        assertEquals("foo.com:1235", address.get(1));
+
+        final List<String> dns = (List<String>) map.get("dns");
+        assertEquals(2, dns.size());
+        assertEquals("barname.testService.mesos:1234", dns.get(0));
+        assertEquals("fooname.testService.mesos:1235", dns.get(1));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
-    public void testGetDnsEmpty() throws Exception {
-        final List dns = resources.client().target("/v1/connection/dns").request().get(List.class);
-        Assert.assertNotNull(dns);
+    public void testGetAddress() throws Exception {
+        final List<String> address = (List<String>) resourceWithVips.client()
+                .target("/v1/connection/address").request().get(List.class);
+        assertEquals(2, address.size());
+        assertEquals("bar.com:1234", address.get(0));
+        assertEquals("foo.com:1235", address.get(1));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testGetDns() throws Exception {
+        final List<String> dns = (List<String>) resourceWithVips.client()
+                .target("/v1/connection/dns").request().get(List.class);
+        assertEquals(2, dns.size());
+        assertEquals("barname.testService.mesos:1234", dns.get(0));
+        assertEquals("fooname.testService.mesos:1235", dns.get(1));
+    }
+
+    private static CassandraDaemonTask getMockTask(String name, String hostname, int nativePort) {
+        CassandraDaemonTask mockTask = Mockito.mock(CassandraDaemonTask.class);
+        when(mockTask.getState()).thenReturn(TaskState.TASK_RUNNING);
+        when(mockTask.getName()).thenReturn(name);
+        when(mockTask.getHostname()).thenReturn(hostname);
+        CassandraConfig cassConf = Mockito.mock(CassandraConfig.class);
+        when(mockTask.getConfig()).thenReturn(cassConf);
+        CassandraApplicationConfig appConf = Mockito.mock(CassandraApplicationConfig.class);
+        when(cassConf.getApplication()).thenReturn(appConf);
+        when(appConf.getNativeTransportPort()).thenReturn(nativePort);
+        return mockTask;
+    }
+
+    private ConnectionResource getConnectionResource(boolean withVips) {
+        ConfigurationManager mockConfigManager = Mockito.mock(ConfigurationManager.class);
+        CassandraSchedulerConfiguration mockSchedulerConfig = Mockito.mock(CassandraSchedulerConfiguration.class);
+        try {
+            when(mockConfigManager.getTargetConfig()).thenReturn(mockSchedulerConfig);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+
+        ServiceConfig mockServiceConfig = Mockito.mock(ServiceConfig.class);
+        when(mockSchedulerConfig.getServiceConfig()).thenReturn(mockServiceConfig);
+        when(mockServiceConfig.getName()).thenReturn(TEST_SERVICE_NAME);
+
+        CassandraTasks mockTasks = Mockito.mock(CassandraTasks.class);
+        when(mockTasks.getDaemons()).thenReturn(TEST_TASKS);
+
+        Capabilities mockCapabilities = Mockito.mock(Capabilities.class);
+        try {
+            when(mockCapabilities.supportsNamedVips()).thenReturn(withVips);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        return new ConnectionResource(mockCapabilities, mockTasks, mockConfigManager);
     }
 }

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/resources/ServiceConfigResourceTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/resources/ServiceConfigResourceTest.java
@@ -3,6 +3,7 @@ package com.mesosphere.dcos.cassandra.scheduler.resources;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.io.Resources;
+import com.mesosphere.dcos.cassandra.common.tasks.CassandraDaemonTask;
 import com.mesosphere.dcos.cassandra.scheduler.config.*;
 import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
@@ -17,13 +18,16 @@ import org.apache.curator.retry.RetryUntilElapsed;
 import org.apache.curator.test.TestingServer;
 import org.apache.mesos.config.ConfigStoreException;
 import org.apache.mesos.curator.CuratorStateStore;
+import org.apache.mesos.dcos.Capabilities;
 import org.apache.mesos.state.StateStore;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 public class ServiceConfigResourceTest {
     private static TestingServer server;
@@ -82,7 +86,11 @@ public class ServiceConfigResourceTest {
                     configuration,
                     configValidator,
                     stateStore);
-            configurationManager = new ConfigurationManager(defaultConfigurationManager);
+            Capabilities mockCapabilities = Mockito.mock(Capabilities.class);
+            when(mockCapabilities.supportsNamedVips()).thenReturn(true);
+            configurationManager = new ConfigurationManager(
+                    new CassandraDaemonTask.Factory(mockCapabilities),
+                    defaultConfigurationManager);
         } catch (ConfigStoreException e) {
             throw new RuntimeException(e);
         }

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/tasks/CassandraTasksTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/tasks/CassandraTasksTest.java
@@ -18,6 +18,7 @@ import org.apache.curator.retry.RetryUntilElapsed;
 import org.apache.curator.test.TestingServer;
 import org.apache.mesos.Protos;
 import org.apache.mesos.curator.CuratorStateStore;
+import org.apache.mesos.dcos.Capabilities;
 import org.apache.mesos.offer.ResourceUtils;
 import org.apache.mesos.offer.TaskException;
 import org.apache.mesos.offer.TaskUtils;
@@ -26,6 +27,9 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -100,7 +104,11 @@ public class CassandraTasksTest {
                 new ConfigValidator(),
                 stateStore);
 
-        configuration = new ConfigurationManager(configurationManager);
+        Capabilities mockCapabilities = Mockito.mock(Capabilities.class);
+        when(mockCapabilities.supportsNamedVips()).thenReturn(true);
+        configuration = new ConfigurationManager(
+                new CassandraDaemonTask.Factory(mockCapabilities),
+                configurationManager);
 
         cassandraTasks = new CassandraTasks(
                 configuration,

--- a/dcos-commons-tools
+++ b/dcos-commons-tools
@@ -1,1 +1,0 @@
-../dcos-commons/tools/

--- a/integration/tests/test_sanity.py
+++ b/integration/tests/test_sanity.py
@@ -24,20 +24,28 @@ def install_framework():
 
 @pytest.mark.sanity
 def test_connect(install_framework):
-    # TODO: remove fallback when universe has recent build with '/connection'
     try:
         result = dcos.http.get(cassandra_api_url('connection'))
+        try:
+            body = result.json()
+            assert len(body) == 3
+            assert len(body["address"]) == DEFAULT_NODE_COUNT
+            assert len(body["dns"]) == DEFAULT_NODE_COUNT
+            assert body["vip"] == 'node.{}.l4lb.thisdcos.directory:9042'.format(PACKAGE_NAME)
+        except:
+            print('Failed to parse connect response')
+            raise
     except:
+        # TODO: remove fallback when universe has recent build with '/connection'
         result = dcos.http.get(cassandra_api_url('nodes/connect'))
-
-    try:
-        body = result.json()
-        assert len(body) == 2
-        assert len(body["address"]) == DEFAULT_NODE_COUNT
-        assert len(body["dns"]) == DEFAULT_NODE_COUNT
-    except:
-        print('Failed to parse connect response')
-        raise
+        try:
+            body = result.json()
+            assert len(body) == 2
+            assert len(body["address"]) == DEFAULT_NODE_COUNT
+            assert len(body["dns"]) == DEFAULT_NODE_COUNT
+        except:
+            print('Failed to parse connect response')
+            raise
 
 
 @pytest.mark.sanity


### PR DESCRIPTION
- ConnectionResource: Add 'vip' entry mirroring Kafka's, plus better tests
- CassandraDaemonTask: Add a dedicated Factory which handles whether named VIPs are available
