### PR TITLE
[CASSANDRA-17] Add ability to customize offer filter refuse_seconds.

### DIFF
--- a/cassandra-scheduler/src/dist/conf/scheduler.yml
+++ b/cassandra-scheduler/src/dist/conf/scheduler.yml
@@ -128,6 +128,7 @@ mesos:
   servers: ${MESOS_SERVERS:-"master.mesos:2181"}
   path: ${MESOS_PATH:-"/mesos"}
   timeout_ms: ${MESOS_TIMEOUT_MS:-10000}
+  refuse_seconds: ${MESOS_REFUSE_SECONDS:-5}
 zookeeper:
   servers: ${ZOOKEEPER_SERVERS:-"master.mesos:2181"}
   session_timeout_ms: 10000

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/CassandraScheduler.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/CassandraScheduler.java
@@ -65,6 +65,7 @@ public class CassandraScheduler implements Scheduler, Managed {
     private final ExecutorService executor;
     private final StateStore stateStore;
     private final DefaultConfigurationManager defaultConfigurationManager;
+    private final Protos.Filters offerFilters;
 
     @Inject
     public CassandraScheduler(
@@ -106,6 +107,8 @@ public class CassandraScheduler implements Scheduler, Managed {
         this.executor = executor;
         this.stateStore = stateStore;
         this.defaultConfigurationManager = defaultConfigurationManager;
+        this.offerFilters = Protos.Filters.newBuilder().setRefuseSeconds(mesosConfig.getRefuseSeconds()).build();
+        LOGGER.info("Creating an offer filter with refuse_seconds = {}", mesosConfig.getRefuseSeconds());
     }
 
     @Override
@@ -364,6 +367,6 @@ public class CassandraScheduler implements Scheduler, Managed {
     private void declineOffer(SchedulerDriver driver, Protos.Offer offer) {
         Protos.OfferID offerId = offer.getId();
         LOGGER.info("Scheduler declining offer: {}", offerId);
-        driver.declineOffer(offerId);
+        driver.declineOffer(offerId, offerFilters);
     }
 }

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/MesosConfig.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/MesosConfig.java
@@ -13,29 +13,34 @@ public class MesosConfig {
     @JsonProperty("path")
     private final String path;
     private final Duration timeout;
+    @JsonProperty("refuse_seconds")
+    private final int refuseSeconds;
 
     public static MesosConfig create(String servers,
                                      String path,
-                                     Duration timeout) {
+                                     Duration timeout,
+                                     int refuseSeconds) {
 
-        return new MesosConfig(servers, path, timeout);
+        return new MesosConfig(servers, path, timeout, refuseSeconds);
     }
 
     @JsonCreator
     public static MesosConfig create(@JsonProperty("servers") String servers,
                                      @JsonProperty("path") String path,
-                                     @JsonProperty("timeout_ms") Long
-                                                 timeoutMs) {
+                                     @JsonProperty("timeout_ms") Long timeoutMs,
+                                     @JsonProperty("refuse_seconds") int refuseSeconds) {
 
         return create(servers,
                 path,
-                Duration.ofMillis(timeoutMs));
+                Duration.ofMillis(timeoutMs),
+                refuseSeconds);
     }
 
-    public MesosConfig(String servers, String path, Duration timeout) {
+    public MesosConfig(String servers, String path, Duration timeout, int refuseSeconds) {
         this.servers = servers;
         this.path = path;
         this.timeout = timeout;
+        this.refuseSeconds = refuseSeconds;
     }
 
     public String getServers() {
@@ -49,6 +54,8 @@ public class MesosConfig {
     public Duration getTimeout() {
         return timeout;
     }
+
+    public int getRefuseSeconds() { return refuseSeconds; }
 
     public String toZooKeeperUrl() {
         return "zk://" + servers + path;
@@ -71,6 +78,7 @@ public class MesosConfig {
                 that.getServers()) : that.getServers() != null) return false;
         if (getPath() != null ? !getPath().equals(
                 that.getPath()) : that.getPath() != null) return false;
+        if (getRefuseSeconds() != that.getRefuseSeconds()) return false;
         return getTimeout() != null ? getTimeout().equals(
                 that.getTimeout()) : that.getTimeout() == null;
 
@@ -81,6 +89,7 @@ public class MesosConfig {
         int result = getServers() != null ? getServers().hashCode() : 0;
         result = 31 * result + (getPath() != null ? getPath().hashCode() : 0);
         result = 31 * result + (getTimeout() != null ? getTimeout().hashCode() : 0);
+        result = 31 * result + getRefuseSeconds();
         return result;
     }
 

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/MutableSchedulerConfiguration.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/config/MutableSchedulerConfiguration.java
@@ -23,7 +23,8 @@ public class MutableSchedulerConfiguration extends Configuration {
     MesosConfig.create(
       "master.mesos:2181",
       "/mesos",
-      10000L
+      10000L,
+      5
     );
   private CuratorFrameworkConfig curatorConfig =
     CuratorFrameworkConfig.create(

--- a/cassandra-scheduler/src/test/resources/scheduler.yml
+++ b/cassandra-scheduler/src/test/resources/scheduler.yml
@@ -128,6 +128,7 @@ mesos:
   servers: ${MESOS_SERVERS:-"localhost:40000"}
   path: ${MESOS_PATH:-"/mesos"}
   timeout_ms: ${MESOS_TIMEOUT_MS:-10000}
+  refuse_seconds: ${MESOS_REFUSE_SECONDS:-5}
 zookeeper:
   servers: ${ZOOKEEPER_SERVERS:-"localhost:40000"}
   session_timeout_ms: 10000


### PR DESCRIPTION
Set the default to 5s so that the default behavior continues as-is.

Fixes https://dcosjira.atlassian.net/browse/CASSANDRA-17.

Same as https://github.com/mesosphere/dcos-cassandra-service/pull/240.