### PR TITLE
Cassandra daemon cannot be restarted properly

### DIFF
--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonBlock.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonBlock.java
@@ -118,8 +118,10 @@ public class CassandraDaemonBlock implements Block {
 
     private OfferRequirement replaceTask(final CassandraDaemonTask task) {
         try {
+            String templateTaskName = CassandraTemplateTask.toTemplateTaskName(task.getName());
+            CassandraTemplateTask templateTask = cassandraTasks.getOrCreateTemplateTask(templateTaskName, task);
             return provider.getReplacementOfferRequirement(
-                    cassandraTasks.createCassandraContainer(cassandraTasks.replaceDaemon(task)));
+                    cassandraTasks.createCassandraContainer(cassandraTasks.replaceDaemon(task), templateTask));
         } catch (PersistenceException ex) {
             LOGGER.error(
                     String.format("Block %s failed to replace task %s,"),


### PR DESCRIPTION
Steps to repro the bug:
1. Set up a cluster with 3 nodes and let the scheduler start Cassandra daemon on the first node as
   the seed.
2. While the 2nd node is in STAGING state, or RUNNING state but before accepting offer from 3rd node,
   kill the Cassandra daemon process on the 2nd node, just to simulate the failure.
3. The result is that the whole cluster will stay in that state and 2nd/3rd node cannot be booted up.

The reason is that, even though there is offer from 2nd node, it failed the evaulation since its
labels don't match the ones in resource requirements of the NEW template task, and thus the wrong
resource pool (MesosResourcePool#unreservedMergedPool) is being used. In the fix, I'm trying to reuse
the existing template task.

Be noted that if you kill any of the Cassandra daemon processes after all of them being started, you
won't have the problem because CassandraRepairScheduler will be used. In this case, the existing
template task will be reused instead of creating a new one.

I manually tested the fix a few times.