### PR TITLE
Add unit test case for pull request #246

### DIFF
--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonBlockTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonBlockTest.java
@@ -4,10 +4,8 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.io.Resources;
 import com.mesosphere.dcos.cassandra.common.config.ClusterTaskConfig;
-import com.mesosphere.dcos.cassandra.common.tasks.CassandraContainer;
-import com.mesosphere.dcos.cassandra.common.tasks.CassandraDaemonTask;
-import com.mesosphere.dcos.cassandra.common.tasks.CassandraMode;
-import com.mesosphere.dcos.cassandra.common.tasks.CassandraTaskExecutor;
+import com.mesosphere.dcos.cassandra.common.config.ExecutorConfig;
+import com.mesosphere.dcos.cassandra.common.tasks.*;
 import com.mesosphere.dcos.cassandra.scheduler.TestUtils;
 import com.mesosphere.dcos.cassandra.scheduler.client.SchedulerClient;
 import com.mesosphere.dcos.cassandra.scheduler.config.*;
@@ -42,6 +40,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class CassandraDaemonBlockTest {
@@ -69,7 +70,7 @@ public class CassandraDaemonBlockTest {
         server = new TestingServer();
         server.start();
 
-        Capabilities mockCapabilities = Mockito.mock(Capabilities.class);
+        Capabilities mockCapabilities = mock(Capabilities.class);
         when(mockCapabilities.supportsNamedVips()).thenReturn(true);
         taskFactory = new CassandraDaemonTask.Factory(mockCapabilities);
 
@@ -122,8 +123,8 @@ public class CassandraDaemonBlockTest {
 
     @Test
     public void testCreate() throws Exception {
-        final CassandraContainer cassandraContainer = Mockito.mock(CassandraContainer.class);
-        final CassandraDaemonTask daemonTask = Mockito.mock(CassandraDaemonTask.class);
+        final CassandraContainer cassandraContainer = mock(CassandraContainer.class);
+        final CassandraDaemonTask daemonTask = mock(CassandraDaemonTask.class);
         final String EXPECTED_NAME = "node-0";
         when(cassandraContainer.getDaemonTask()).thenReturn(daemonTask);
         when(daemonTask.getName()).thenReturn(EXPECTED_NAME);
@@ -140,7 +141,7 @@ public class CassandraDaemonBlockTest {
         CassandraDaemonBlock block = CassandraDaemonBlock.create(
                 EXPECTED_NAME, persistentOfferRequirementProvider, cassandraTasks, client);
 
-        final OfferRequirement mockOfferReq = Mockito.mock(OfferRequirement.class);
+        final OfferRequirement mockOfferReq = mock(OfferRequirement.class);
         when(persistentOfferRequirementProvider.getNewOfferRequirement(Mockito.any())).thenReturn(mockOfferReq);
 
         final OfferRequirement offerRequirement = block.start();
@@ -153,7 +154,7 @@ public class CassandraDaemonBlockTest {
         CassandraDaemonBlock block = CassandraDaemonBlock.create(
                 EXPECTED_NAME, persistentOfferRequirementProvider, cassandraTasks, client);
 
-        final OfferRequirement mockOfferReq = Mockito.mock(OfferRequirement.class);
+        final OfferRequirement mockOfferReq = mock(OfferRequirement.class);
         when(persistentOfferRequirementProvider.getNewOfferRequirement(Mockito.any())).thenReturn(mockOfferReq);
 
         OfferRequirement offerRequirement = block.start();
@@ -182,7 +183,7 @@ public class CassandraDaemonBlockTest {
         CassandraDaemonBlock block = CassandraDaemonBlock.create(
                 EXPECTED_NAME, persistentOfferRequirementProvider, cassandraTasks, client);
 
-        final OfferRequirement mockOfferReq = Mockito.mock(OfferRequirement.class);
+        final OfferRequirement mockOfferReq = mock(OfferRequirement.class);
         when(persistentOfferRequirementProvider.getNewOfferRequirement(Mockito.any())).thenReturn(mockOfferReq);
 
         OfferRequirement offerRequirement = block.start();
@@ -210,7 +211,7 @@ public class CassandraDaemonBlockTest {
         CassandraDaemonBlock block = CassandraDaemonBlock.create(
                 EXPECTED_NAME, persistentOfferRequirementProvider, cassandraTasks, client);
 
-        final OfferRequirement mockOfferReq = Mockito.mock(OfferRequirement.class);
+        final OfferRequirement mockOfferReq = mock(OfferRequirement.class);
         when(persistentOfferRequirementProvider.getNewOfferRequirement(Mockito.any())).thenReturn(mockOfferReq);
 
         OfferRequirement offerRequirement = block.start();
@@ -249,7 +250,7 @@ public class CassandraDaemonBlockTest {
         CassandraDaemonBlock block = CassandraDaemonBlock.create(
                 EXPECTED_NAME, persistentOfferRequirementProvider, cassandraTasks, client);
 
-        final OfferRequirement mockOfferReq = Mockito.mock(OfferRequirement.class);
+        final OfferRequirement mockOfferReq = mock(OfferRequirement.class);
         when(persistentOfferRequirementProvider.getNewOfferRequirement(Mockito.any())).thenReturn(mockOfferReq);
 
         OfferRequirement offerRequirement = block.start();
@@ -288,7 +289,7 @@ public class CassandraDaemonBlockTest {
         CassandraDaemonBlock block = CassandraDaemonBlock.create(
                 EXPECTED_NAME, persistentOfferRequirementProvider, cassandraTasks, client);
 
-        final OfferRequirement mockOfferReq = Mockito.mock(OfferRequirement.class);
+        final OfferRequirement mockOfferReq = mock(OfferRequirement.class);
         when(persistentOfferRequirementProvider.getNewOfferRequirement(Mockito.any())).thenReturn(mockOfferReq);
 
         OfferRequirement offerRequirement = block.start();
@@ -315,7 +316,7 @@ public class CassandraDaemonBlockTest {
         final String EXPECTED_NAME = "node-0";
         CassandraDaemonBlock block = CassandraDaemonBlock.create(EXPECTED_NAME,
                 persistentOfferRequirementProvider, cassandraTasks, client);
-        final OfferRequirement mockOfferReq = Mockito.mock(OfferRequirement.class);
+        final OfferRequirement mockOfferReq = mock(OfferRequirement.class);
         when(persistentOfferRequirementProvider.getNewOfferRequirement(Mockito.any())).thenReturn(mockOfferReq);
 
         OfferRequirement offerRequirement = block.start();
@@ -340,12 +341,52 @@ public class CassandraDaemonBlockTest {
     }
 
     @Test
+    public void start_whenContainerTerminated_shouldUseExistingTemplateTask() throws Exception {
+        String nodeName = "node-2";
+        CassandraContainer container = mock(CassandraContainer.class);
+        when(container.getAgentId()).thenReturn("agent-2");
+        when(container.isTerminated()).thenReturn(true);
+
+        CassandraTasks tasks = mock(CassandraTasks.class);
+        when(tasks.getOrCreateContainer(nodeName)).thenReturn(container);
+
+        CassandraDaemonTask daemonTask = taskFactory.create(
+                nodeName,
+                "abc",
+                CassandraTaskExecutor.create("1234", nodeName, "role", "principal", config.getExecutorConfig()),
+                config.getCassandraConfig());
+        when(container.getDaemonTask()).thenReturn(daemonTask);
+        Protos.TaskInfo taskInfo = daemonTask.getTaskInfo();
+        taskInfo = Protos.TaskInfo.newBuilder(taskInfo)
+                .setSlaveId(Protos.SlaveID.newBuilder().setValue("1.2.3.4").build())
+                .build();
+        Protos.TaskStatus taskStatus = TestUtils.generateStatus(taskInfo.getTaskId(), Protos.TaskState.TASK_ERROR);
+        StateStore stateStore = mock(StateStore.class);
+        when(stateStore.fetchStatus(anyString())).thenReturn(taskStatus);
+        when(tasks.getStateStore()).thenReturn(stateStore);
+
+        CassandraTemplateTask templateTask = mock(CassandraTemplateTask.class);
+        when(tasks.getOrCreateTemplateTask(nodeName + "-task-template", daemonTask)).thenReturn(templateTask);
+
+        CassandraDaemonTask newDaemonTask = mock(CassandraDaemonTask.class);
+        when(tasks.replaceDaemon(daemonTask)).thenReturn(newDaemonTask);
+        when(tasks.createCassandraContainer(newDaemonTask, templateTask)).thenReturn(container);
+
+        CassandraDaemonBlock block = CassandraDaemonBlock.create(nodeName,
+                persistentOfferRequirementProvider, tasks, client);
+        block.start();
+
+        verify(persistentOfferRequirementProvider).getReplacementOfferRequirement(container);
+        verify(tasks).createCassandraContainer(newDaemonTask, templateTask);
+    }
+
+    @Test
     public void testStartLaunching() throws Exception {
         final String EXPECTED_NAME = "node-0";
         CassandraDaemonBlock block = CassandraDaemonBlock.create(
                 EXPECTED_NAME, persistentOfferRequirementProvider, cassandraTasks, client);
 
-        final OfferRequirement mockOfferReq = Mockito.mock(OfferRequirement.class);
+        final OfferRequirement mockOfferReq = mock(OfferRequirement.class);
         when(persistentOfferRequirementProvider.getNewOfferRequirement(Mockito.any())).thenReturn(mockOfferReq);
 
         OfferRequirement offerRequirement = block.start();
@@ -377,7 +418,7 @@ public class CassandraDaemonBlockTest {
         CassandraDaemonBlock block = CassandraDaemonBlock.create(
                 EXPECTED_NAME, persistentOfferRequirementProvider, cassandraTasks, client);
 
-        final OfferRequirement mockOfferReq = Mockito.mock(OfferRequirement.class);
+        final OfferRequirement mockOfferReq = mock(OfferRequirement.class);
         when(persistentOfferRequirementProvider.getNewOfferRequirement(Mockito.any())).thenReturn(mockOfferReq);
 
         OfferRequirement offerRequirement = block.start();
@@ -404,7 +445,7 @@ public class CassandraDaemonBlockTest {
         CassandraDaemonBlock block = CassandraDaemonBlock.create(
                 EXPECTED_NAME, persistentOfferRequirementProvider, cassandraTasks, client);
 
-        final OfferRequirement mockOfferReq = Mockito.mock(OfferRequirement.class);
+        final OfferRequirement mockOfferReq = mock(OfferRequirement.class);
         when(persistentOfferRequirementProvider.getNewOfferRequirement(Mockito.any())).thenReturn(mockOfferReq);
 
         OfferRequirement offerRequirement = block.start();

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonBlockTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonBlockTest.java
@@ -31,9 +31,11 @@ import org.apache.mesos.state.StateStore;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.powermock.reflect.Whitebox;
 
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
@@ -339,6 +341,12 @@ public class CassandraDaemonBlockTest {
         when(persistentOfferRequirementProvider.getReplacementOfferRequirement(any())).thenReturn(mockOfferReq);
         offerRequirement = block.start();
         Assert.assertEquals(mockOfferReq, offerRequirement);
+
+        CassandraTemplateTask templateTask = cassandraTasks.getOrCreateTemplateTask(
+                CassandraTemplateTask.toTemplateTaskName(task.getName()), task);
+        ArgumentCaptor<CassandraContainer> containerCaptor = ArgumentCaptor.forClass(CassandraContainer.class);
+        verify(persistentOfferRequirementProvider).getReplacementOfferRequirement(containerCaptor.capture());
+        Assert.assertEquals(templateTask, Whitebox.getInternalState(containerCaptor.getValue(), "clusterTemplateTask"));
     }
 
     @Test


### PR DESCRIPTION
Ideally I should able to add a few asserts in testStartTerminated() to cover my fix. However, testStartTerminated() is broken and if you debug to see the behavior, it doesn't really go to the below branch in CassandraDaemonBlock#start:
`else  if (container.isTerminated() || container.isLaunching())`

So in this case, I have to create my own test case and make it as independent as possible, if you want to refactor the unit test cases later on.