### PR TITLE
Set task config target properly to exercise replaceTask logic

### DIFF
--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonBlockTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonBlockTest.java
@@ -321,8 +321,9 @@ public class CassandraDaemonBlockTest {
         OfferRequirement offerRequirement = block.start();
         Assert.assertNotNull(offerRequirement);
 
+        String target = new ConfigurationManager(taskFactory, configurationManager).getTargetConfigName().toString();
         final CassandraDaemonTask task = taskFactory.create(EXPECTED_NAME,
-                "abc",
+                target,
                 CassandraTaskExecutor.create("1234", EXPECTED_NAME, "cassandra-role", "cassandra-principal",
                         config.getExecutorConfig()),
                 config.getCassandraConfig());


### PR DESCRIPTION
Per [#247](https://github.com/mesosphere/dcos-cassandra-service/pull/247), `testStartTerminated` does not currently exercise the `replaceTask` logic that it ought to. This is because the fake failing task is initialized with a dummy target config value, causing the block to think that it should update the task configuration rather than replace it. This change initializes the target configuration correctly for this case.