### PR TITLE
Make Cleanup CLI operation API contract compliant

### DIFF
--- a/cli/dcos-cassandra/main.go
+++ b/cli/dcos-cassandra/main.go
@@ -221,8 +221,13 @@ type CleanupRepairHandler struct {
 }
 func (cmd *CleanupRepairHandler) getArgs() map[string]interface{} {
 	nodesList := []string{}
-	for _, node := range strings.Split(cmd.nodes, ",") {
-		nodesList = append(nodesList, fmt.Sprintf("node-%s", strings.TrimSpace(node)))
+	nodesSplit := strings.Split(cmd.nodes, ",")
+	if sliceContains(nodesSplit, "*") {
+		nodesList = append(nodesList, "*")
+	} else {
+		for _, node := range nodesSplit {
+			nodesList = append(nodesList, fmt.Sprintf("node-%s", strings.TrimSpace(node)))
+		}
 	}
 
 	dict := map[string]interface{} {"nodes": nodesList}
@@ -283,4 +288,12 @@ func handleCleanupRepairSections(app *kingpin.Application) {
 	repair.Command(
 		"stop",
 		"Stops a currently running repair").Action(cmd.runRepairStop)
+}
+func sliceContains(stringSlice []string, searchString string) bool {
+	for _, value := range stringSlice {
+		if value == searchString {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This PR updates the Go CLI, and hence now complies to API contract:
1. Pass nodes:["*"] when cleanup should be run against all nodes
2. Else, pass nodes:["node-<0, 1, ...>, ...] when cleanup should be run against a sub-set of nodes.
