### PR TITLE
Add compile dependency protobuf-3

### DIFF
--- a/cassandra-commons/build.gradle
+++ b/cassandra-commons/build.gradle
@@ -3,6 +3,7 @@ targetCompatibility = '1.8'
 
 apply plugin: 'com.google.protobuf'
 dependencies {
+    compile 'com.google.protobuf:protobuf-java:3.0.0'
     compile 'mesosphere:dcos-commons:0.7.6-SNAPSHOT'
     compile 'org.apache.cassandra:cassandra-all:2.2.4'
 }

--- a/cassandra-commons/build.gradle
+++ b/cassandra-commons/build.gradle
@@ -9,6 +9,9 @@ dependencies {
 }
 protobuf {
     generatedFilesBaseDir = "$projectDir/src/generated"
+    protoc {
+        artifact = 'com.google.protobuf:protoc:3.0.0'
+    }
 }
 idea.module {
     sourceDirs += file("$projectDir/src/generated/main/java")


### PR DESCRIPTION
Issue: cassandra-commons:compileJava build failed for missing protobuf
JIRA: https://dcosjira.atlassian.net/browse/CASSANDRA-26