### PR TITLE
Contain protobuf

### DIFF
--- a/cassandra-commons/build.gradle
+++ b/cassandra-commons/build.gradle
@@ -7,6 +7,9 @@ dependencies {
     compile 'org.apache.cassandra:cassandra-all:2.2.4'
 }
 protobuf {
+    protoc {
+        artifact = 'com.google.protobuf:protoc:2.5.0'
+    }
     generatedFilesBaseDir = "$projectDir/src/generated"
 }
 idea.module {

--- a/dev-guide.md
+++ b/dev-guide.md
@@ -2,7 +2,6 @@
 
 ## Requirements
 - JDK 8
-- Protobuf 2.5.0
 - GNU Sed 4.2.2 + (for generating new apache-casssandra package using `build-cassandra-bin.bash`)
 
 ## Clone the repo (including sub-modules)


### PR DESCRIPTION
Google agreed to publish Protobuf 2.5.0 https://github.com/google/protobuf/issues/2147
This removes the requirement of people having to install an old version of Protobuf on their machine (which might not work with other things they're doing). It also removes the dependency from wherever it's being built whether that's in a container or a server that needs 2.5.0 installed.