### PR TITLE
Add options file for testing against strict-mode clusters

### DIFF
--- a/integration/data/strict_options.json
+++ b/integration/data/strict_options.json
@@ -1,0 +1,7 @@
+{
+  "service": {
+    "user": "nobody",
+    "principal": "service-acct",
+    "secret_name": "secret"
+  }
+}


### PR DESCRIPTION
The tools in [dcos-commons](https://github.com/mesosphere/dcos-commons/tree/master/tools) automate the creation of a principal and ACLs for clusters running in strict mode. Frameworks in this case must launch with non-default principals, secrets and user names. This configuration file matches the principal, user, and secret created by the `dcos-commons` tools, allowing for simple test-running against strict mode clusters.