### PR TITLE
Run janitor with correct principal and master url when in strict mode

### DIFF
--- a/integration/tests/command.py
+++ b/integration/tests/command.py
@@ -7,7 +7,9 @@ import shakedown
 
 from tests.defaults import (
     DEFAULT_NODE_COUNT,
+    IS_STRICT,
     PACKAGE_NAME,
+    PRINCIPAL,
     TASK_RUNNING_STATE,
 )
 
@@ -114,9 +116,11 @@ def uninstall():
         print('Got exception when uninstalling package, continuing with janitor anyway: {}'.format(e))
 
     shakedown.run_command_on_master(
-        'docker run mesosphere/janitor /janitor.py '
-        '-r cassandra-role -p cassandra-principal -z dcos-service-cassandra '
+        'docker run mesosphere/janitor /janitor.py {}'
+        '-r cassandra-role -p {} -z dcos-service-cassandra '
         '--auth_token={}'.format(
+            '-m https://leader.mesos:5050/master/ ' if IS_STRICT else '',
+            PRINCIPAL,
             shakedown.run_dcos_command(
                 'config show core.dcos_acs_token'
             )[0].strip()

--- a/integration/tests/defaults.py
+++ b/integration/tests/defaults.py
@@ -8,3 +8,6 @@ TASK_RUNNING_STATE = 'TASK_RUNNING'
 
 DCOS_URL = shakedown.run_dcos_command('config show core.dcos_url')[0].strip()
 OPTIONS_FILE = os.environ.get('OPTIONS_FILE')
+
+IS_STRICT = bool(os.environ.get('STRICT_MODE', 'False'))
+PRINCIPAL = os.environ.get('FRAMEWORK_PRINCIPAL', 'cassandra-principal')


### PR DESCRIPTION
When testing against a DC/OS cluster in strict mode, janitor must use an HTTPS URI for the Mesos master, and a custom principal must be configurable. This change enables the shakedown tests to ascertain these values from environment variables.