### PR TITLE
Bump version number to 1.0.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ allprojects {
     apply from: "$rootDir/gradle/spock.gradle"
 
     group = 'com.mesosphere.dcos'
-    version = '1.0.16'
+    version = '1.0.18'
 
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'


### PR DESCRIPTION
As 1.0.17 is released, the version should be bumped to 1.0.18.