### PR TITLE
Speed up tests by only re-installing when needed, finish strict mode support

### DIFF
--- a/integration/data/strict_options.json
+++ b/integration/data/strict_options.json
@@ -1,7 +1,0 @@
-{
-  "service": {
-    "user": "nobody",
-    "principal": "service-acct",
-    "secret_name": "secret"
-  }
-}

--- a/integration/tests/command.py
+++ b/integration/tests/command.py
@@ -126,7 +126,7 @@ def uninstall():
 
     shakedown.run_command_on_master(
         'docker run mesosphere/janitor /janitor.py '
-        '-v -r cassandra-role -p {} -z dcos-service-cassandra '
+        '-r cassandra-role -p {} -z dcos-service-cassandra '
         '--auth_token={}'.format(
             PRINCIPAL,
             shakedown.run_dcos_command(

--- a/integration/tests/command.py
+++ b/integration/tests/command.py
@@ -143,6 +143,7 @@ def unset_ssl_verification():
 def _nested_dict_merge(a, b, path=None):
     "ripped from http://stackoverflow.com/questions/7204805/dictionaries-of-dictionaries-merge"
     if path is None: path = []
+    a = a.copy()
     for key in b:
         if key in a:
             if isinstance(a[key], dict) and isinstance(b[key], dict):

--- a/integration/tests/command.py
+++ b/integration/tests/command.py
@@ -7,7 +7,7 @@ import shakedown
 
 from tests.defaults import (
     DEFAULT_NODE_COUNT,
-    IS_STRICT,
+    DEFAULT_OPTIONS_DICT,
     PACKAGE_NAME,
     PRINCIPAL,
     TASK_RUNNING_STATE,
@@ -93,19 +93,28 @@ def request(request_fn, *args, **kwargs):
 
 
 def spin(fn, success_predicate, *args, **kwargs):
-    end_time = time.time() + WAIT_TIME_IN_SECONDS
-    while time.time() < end_time:
+    now = time.time()
+    end_time = now + WAIT_TIME_IN_SECONDS
+    while now < end_time:
+        print("%s: %.01fs left" % (time.strftime("%H:%M:%S %Z", time.localtime(now)), end_time - now))
         result = fn(*args, **kwargs)
         is_successful, error_message = success_predicate(result)
         if is_successful:
-            print('Success state reached, exiting spin. prev_err={}'.format(error_message))
+            print('Success state reached, exiting spin.')
             break
         print('Waiting for success state... err={}'.format(error_message))
         time.sleep(1)
+        now = time.time()
 
     assert is_successful, error_message
 
     return result
+
+
+def install(additional_options = {}):
+    merged_options = _nested_dict_merge(DEFAULT_OPTIONS_DICT, additional_options)
+    print('Installing {} with options: {}'.format(PACKAGE_NAME, merged_options))
+    shakedown.install_package_and_wait(PACKAGE_NAME, options_json=merged_options)
 
 
 def uninstall():
@@ -116,10 +125,9 @@ def uninstall():
         print('Got exception when uninstalling package, continuing with janitor anyway: {}'.format(e))
 
     shakedown.run_command_on_master(
-        'docker run mesosphere/janitor /janitor.py {}'
-        '-r cassandra-role -p {} -z dcos-service-cassandra '
+        'docker run mesosphere/janitor /janitor.py '
+        '-v -r cassandra-role -p {} -z dcos-service-cassandra '
         '--auth_token={}'.format(
-            '-m https://leader.mesos:5050/master/ ' if IS_STRICT else '',
             PRINCIPAL,
             shakedown.run_dcos_command(
                 'config show core.dcos_acs_token'
@@ -130,3 +138,19 @@ def uninstall():
 
 def unset_ssl_verification():
     shakedown.run_dcos_command('config set core.ssl_verify false')
+
+
+def _nested_dict_merge(a, b, path=None):
+    "ripped from http://stackoverflow.com/questions/7204805/dictionaries-of-dictionaries-merge"
+    if path is None: path = []
+    for key in b:
+        if key in a:
+            if isinstance(a[key], dict) and isinstance(b[key], dict):
+                _nested_dict_merge(a[key], b[key], path + [str(key)])
+            elif a[key] == b[key]:
+                pass # same leaf value
+            else:
+                raise Exception('Conflict at %s' % '.'.join(path + [str(key)]))
+        else:
+            a[key] = b[key]
+    return a

--- a/integration/tests/defaults.py
+++ b/integration/tests/defaults.py
@@ -7,7 +7,19 @@ PACKAGE_NAME = 'cassandra'
 TASK_RUNNING_STATE = 'TASK_RUNNING'
 
 DCOS_URL = shakedown.run_dcos_command('config show core.dcos_url')[0].strip()
-OPTIONS_FILE = os.environ.get('OPTIONS_FILE')
 
-IS_STRICT = bool(os.environ.get('STRICT_MODE', 'False'))
-PRINCIPAL = os.environ.get('FRAMEWORK_PRINCIPAL', 'cassandra-principal')
+# expected SECURITY values: 'permissive', 'strict', 'disabled'
+if os.environ.get('SECURITY', '') == 'strict':
+    print('Using strict mode test configuration')
+    PRINCIPAL = 'service-acct'
+    DEFAULT_OPTIONS_DICT = {
+        "service": {
+            "user": "nobody",
+            "principal": PRINCIPAL,
+            "secret_name": "secret"
+        }
+    }
+else:
+    print('Using default test configuration')
+    PRINCIPAL = 'cassandra-principal'
+    DEFAULT_OPTIONS_DICT = {}

--- a/integration/tests/test_recovery.py
+++ b/integration/tests/test_recovery.py
@@ -7,13 +7,14 @@ from tests.command import (
     cassandra_api_url,
     check_health,
     get_cassandra_config,
+    install,
     marathon_api_url,
     request,
     spin,
     uninstall,
     unset_ssl_verification,
 )
-from tests.defaults import DEFAULT_NODE_COUNT, OPTIONS_FILE, PACKAGE_NAME
+from tests.defaults import DEFAULT_NODE_COUNT, PACKAGE_NAME
 
 
 def bump_cpu_count_config():
@@ -127,29 +128,28 @@ def run_repair():
     )
 
 
+# install once up-front, reuse install for tests (MUCH FASTER):
 def setup_module():
     unset_ssl_verification()
 
-
-@pytest.yield_fixture
-def install_framework():
-    shakedown.install_package_and_wait(PACKAGE_NAME, options_file=OPTIONS_FILE)
+    uninstall()
+    install()
     check_health()
 
-    yield
 
+def teardown_module():
     uninstall()
 
 
 @pytest.mark.recovery
-def test_kill_task_in_node(install_framework):
+def test_kill_task_in_node():
     kill_task_with_pattern('CassandraDaemon', get_node_host())
 
     check_health()
 
 
 @pytest.mark.recovery
-def test_kill_all_task_in_node(install_framework):
+def test_kill_all_task_in_node():
     for host in shakedown.get_service_ips(PACKAGE_NAME):
         kill_task_with_pattern('CassandraDaemon', host)
 
@@ -157,21 +157,21 @@ def test_kill_all_task_in_node(install_framework):
 
 
 @pytest.mark.recovery
-def test_scheduler_died(install_framework):
+def test_scheduler_died():
     kill_task_with_pattern('cassandra.scheduler.Main', get_scheduler_host())
 
     check_health()
 
 
 @pytest.mark.recovery
-def test_executor_killed(install_framework):
+def test_executor_killed():
     kill_task_with_pattern('cassandra.executor.Main', get_node_host())
 
     check_health()
 
 
 @pytest.mark.recovery
-def test_all_executors_killed(install_framework):
+def test_all_executors_killed():
     for host in shakedown.get_service_ips(PACKAGE_NAME):
         kill_task_with_pattern('cassandra.executor.Main', host)
 
@@ -179,21 +179,21 @@ def test_all_executors_killed(install_framework):
 
 
 @pytest.mark.recovery
-def test_master_killed(install_framework):
+def test_master_killed():
     kill_task_with_pattern('mesos-master')
 
     check_health()
 
 
 @pytest.mark.recovery
-def test_zk_killed(install_framework):
+def test_zk_killed():
     kill_task_with_pattern('zookeeper')
 
     check_health()
 
 
 @pytest.mark.recovery
-def test_partition(install_framework):
+def test_partition():
     host = get_node_host()
 
     shakedown.partition_agent(host)
@@ -203,7 +203,7 @@ def test_partition(install_framework):
 
 
 @pytest.mark.recovery
-def test_partition_master_both_ways(install_framework):
+def test_partition_master_both_ways():
     shakedown.partition_master()
     shakedown.reconnect_master()
 
@@ -211,7 +211,7 @@ def test_partition_master_both_ways(install_framework):
 
 
 @pytest.mark.recovery
-def test_partition_master_incoming(install_framework):
+def test_partition_master_incoming():
     shakedown.partition_master(incoming=True, outgoing=False)
     shakedown.reconnect_master()
 
@@ -219,7 +219,7 @@ def test_partition_master_incoming(install_framework):
 
 
 @pytest.mark.recovery
-def test_partition_master_outgoing(install_framework):
+def test_partition_master_outgoing():
     shakedown.partition_master(incoming=False, outgoing=True)
     shakedown.reconnect_master()
 
@@ -227,7 +227,7 @@ def test_partition_master_outgoing(install_framework):
 
 
 @pytest.mark.recovery
-def test_all_partition(install_framework):
+def test_all_partition():
     hosts = shakedown.get_service_ips(PACKAGE_NAME)
 
     for host in hosts:
@@ -239,7 +239,7 @@ def test_all_partition(install_framework):
 
 
 @pytest.mark.recovery
-def test_config_update_then_kill_task_in_node(install_framework):
+def test_config_update_then_kill_task_in_node():
     host = get_node_host()
     run_planned_operation(
         bump_cpu_count_config,
@@ -250,7 +250,7 @@ def test_config_update_then_kill_task_in_node(install_framework):
 
 
 @pytest.mark.recovery
-def test_config_update_then_kill_all_task_in_node(install_framework):
+def test_config_update_then_kill_all_task_in_node():
     hosts = shakedown.get_service_ips(PACKAGE_NAME)
     run_planned_operation(
         bump_cpu_count_config,
@@ -261,7 +261,7 @@ def test_config_update_then_kill_all_task_in_node(install_framework):
 
 
 @pytest.mark.recovery
-def test_config_update_then_scheduler_died(install_framework):
+def test_config_update_then_scheduler_died():
     host = get_scheduler_host()
     run_planned_operation(
         bump_cpu_count_config,
@@ -272,7 +272,7 @@ def test_config_update_then_scheduler_died(install_framework):
 
 
 @pytest.mark.recovery
-def test_config_update_then_executor_killed(install_framework):
+def test_config_update_then_executor_killed():
     host = get_node_host()
     run_planned_operation(
         bump_cpu_count_config,
@@ -283,7 +283,7 @@ def test_config_update_then_executor_killed(install_framework):
 
 
 @pytest.mark.recovery
-def test_config_update_then_all_executors_killed(install_framework):
+def test_config_update_then_all_executors_killed():
     hosts = shakedown.get_service_ips(PACKAGE_NAME)
     run_planned_operation(
         bump_cpu_count_config,
@@ -296,7 +296,7 @@ def test_config_update_then_all_executors_killed(install_framework):
 
 
 @pytest.mark.recovery
-def test_config_update_then_master_killed(install_framework):
+def test_config_update_then_master_killed():
     run_planned_operation(
         bump_cpu_count_config, lambda: kill_task_with_pattern('mesos-master')
     )
@@ -305,7 +305,7 @@ def test_config_update_then_master_killed(install_framework):
 
 
 @pytest.mark.recovery
-def test_config_update_then_zk_killed(install_framework):
+def test_config_update_then_zk_killed():
     run_planned_operation(
         bump_cpu_count_config, lambda: kill_task_with_pattern('zookeeper')
     )
@@ -314,7 +314,7 @@ def test_config_update_then_zk_killed(install_framework):
 
 
 @pytest.mark.recovery
-def test_config_update_then_partition(install_framework):
+def test_config_update_then_partition():
     host = get_node_host()
 
     def partition():
@@ -327,7 +327,7 @@ def test_config_update_then_partition(install_framework):
 
 
 @pytest.mark.recovery
-def test_config_update_then_all_partition(install_framework):
+def test_config_update_then_all_partition():
     hosts = shakedown.get_service_ips(PACKAGE_NAME)
 
     def partition():
@@ -342,7 +342,7 @@ def test_config_update_then_all_partition(install_framework):
 
 
 @pytest.mark.recovery
-def test_cleanup_then_kill_task_in_node(install_framework):
+def test_cleanup_then_kill_task_in_node():
     host = get_node_host()
     run_planned_operation(
         run_cleanup,
@@ -353,7 +353,7 @@ def test_cleanup_then_kill_task_in_node(install_framework):
 
 
 @pytest.mark.recovery
-def test_cleanup_then_kill_all_task_in_node(install_framework):
+def test_cleanup_then_kill_all_task_in_node():
     hosts = shakedown.get_service_ips(PACKAGE_NAME)
     run_planned_operation(
         run_cleanup,
@@ -364,7 +364,7 @@ def test_cleanup_then_kill_all_task_in_node(install_framework):
 
 
 @pytest.mark.recovery
-def test_cleanup_then_scheduler_died(install_framework):
+def test_cleanup_then_scheduler_died():
     host = get_scheduler_host()
     run_planned_operation(
         run_cleanup,
@@ -375,7 +375,7 @@ def test_cleanup_then_scheduler_died(install_framework):
 
 
 @pytest.mark.recovery
-def test_cleanup_then_executor_killed(install_framework):
+def test_cleanup_then_executor_killed():
     host = get_node_host()
     run_planned_operation(
         run_cleanup,
@@ -386,7 +386,7 @@ def test_cleanup_then_executor_killed(install_framework):
 
 
 @pytest.mark.recovery
-def test_cleanup_then_all_executors_killed(install_framework):
+def test_cleanup_then_all_executors_killed():
     hosts = shakedown.get_service_ips(PACKAGE_NAME)
     run_planned_operation(
         run_cleanup(),
@@ -399,7 +399,7 @@ def test_cleanup_then_all_executors_killed(install_framework):
 
 
 @pytest.mark.recovery
-def test_cleanup_then_master_killed(install_framework):
+def test_cleanup_then_master_killed():
     run_planned_operation(
         run_cleanup(), lambda: kill_task_with_pattern('mesos-master')
     )
@@ -408,7 +408,7 @@ def test_cleanup_then_master_killed(install_framework):
 
 
 @pytest.mark.recovery
-def test_cleanup_then_zk_killed(install_framework):
+def test_cleanup_then_zk_killed():
     run_planned_operation(
         run_cleanup(), lambda: kill_task_with_pattern('zookeeper')
     )
@@ -417,7 +417,7 @@ def test_cleanup_then_zk_killed(install_framework):
 
 
 @pytest.mark.recovery
-def test_cleanup_then_partition(install_framework):
+def test_cleanup_then_partition():
     host = get_node_host()
 
     def partition():
@@ -430,7 +430,7 @@ def test_cleanup_then_partition(install_framework):
 
 
 @pytest.mark.recovery
-def test_cleanup_then_all_partition(install_framework):
+def test_cleanup_then_all_partition():
     hosts = shakedown.get_service_ips(PACKAGE_NAME)
 
     def partition():
@@ -445,7 +445,7 @@ def test_cleanup_then_all_partition(install_framework):
 
 
 @pytest.mark.recovery
-def test_repair_then_kill_task_in_node(install_framework):
+def test_repair_then_kill_task_in_node():
     host = get_node_host()
     run_planned_operation(
         run_repair,
@@ -456,7 +456,7 @@ def test_repair_then_kill_task_in_node(install_framework):
 
 
 @pytest.mark.recovery
-def test_repair_then_kill_all_task_in_node(install_framework):
+def test_repair_then_kill_all_task_in_node():
     hosts = shakedown.get_service_ips(PACKAGE_NAME)
     run_planned_operation(
         run_repair,
@@ -467,7 +467,7 @@ def test_repair_then_kill_all_task_in_node(install_framework):
 
 
 @pytest.mark.recovery
-def test_repair_then_scheduler_died(install_framework):
+def test_repair_then_scheduler_died():
     host = get_scheduler_host()
     run_planned_operation(
         run_repair,
@@ -478,7 +478,7 @@ def test_repair_then_scheduler_died(install_framework):
 
 
 @pytest.mark.recovery
-def test_repair_then_executor_killed(install_framework):
+def test_repair_then_executor_killed():
     host = get_node_host()
     run_planned_operation(
         run_repair,
@@ -489,7 +489,7 @@ def test_repair_then_executor_killed(install_framework):
 
 
 @pytest.mark.recovery
-def test_repair_then_all_executors_killed(install_framework):
+def test_repair_then_all_executors_killed():
     hosts = shakedown.get_service_ips(PACKAGE_NAME)
     run_planned_operation(
         run_repair,
@@ -502,7 +502,7 @@ def test_repair_then_all_executors_killed(install_framework):
 
 
 @pytest.mark.recovery
-def test_repair_then_master_killed(install_framework):
+def test_repair_then_master_killed():
     run_planned_operation(
         run_repair,
         lambda: kill_task_with_pattern('mesos-master')
@@ -512,7 +512,7 @@ def test_repair_then_master_killed(install_framework):
 
 
 @pytest.mark.recovery
-def test_repair_then_zk_killed(install_framework):
+def test_repair_then_zk_killed():
     run_planned_operation(
         run_repair,
         lambda: kill_task_with_pattern('zookeeper')
@@ -522,7 +522,7 @@ def test_repair_then_zk_killed(install_framework):
 
 
 @pytest.mark.recovery
-def test_repair_then_partition(install_framework):
+def test_repair_then_partition():
     host = get_node_host()
 
     def partition():
@@ -535,7 +535,7 @@ def test_repair_then_partition(install_framework):
 
 
 @pytest.mark.recovery
-def test_repair_then_all_partition(install_framework):
+def test_repair_then_all_partition():
     hosts = shakedown.get_service_ips(PACKAGE_NAME)
 
     def partition():

--- a/integration/tests/test_sanity.py
+++ b/integration/tests/test_sanity.py
@@ -35,9 +35,10 @@ def teardown_module():
 def test_connect():
     result = dcos.http.get(cassandra_api_url('connection'))
     body = result.json()
-    assert len(body) == 2
+    assert len(body) == 3
     assert len(body["address"]) == DEFAULT_NODE_COUNT
     assert len(body["dns"]) == DEFAULT_NODE_COUNT
+    assert body["vip"] == 'node.{}.l4lb.thisdcos.directory:9042'.format(PACKAGE_NAME)
 
 
 @pytest.mark.sanity

--- a/test.sh
+++ b/test.sh
@@ -22,6 +22,11 @@ else
     echo "Using provided CLUSTER_URL as cluster: $CLUSTER_URL"
 fi
 
+echo Security: $SECURITY
+if [ "$SECURITY" = "strict" ]; then
+    ${REPO_ROOT_DIR}/dcos-commons-tools/setup_permissions.sh nobody cassandra-role
+fi
+
 # Run shakedown tests:
 ${REPO_ROOT_DIR}/dcos-commons-tools/run_tests.py shakedown ${REPO_ROOT_DIR}/integration/tests/ ${REPO_ROOT_DIR}/integration/requirements.txt
 


### PR DESCRIPTION
- Just install once at the start of the suite, only reinstall if needed
- Better logging in spin()
- Streamlined handling of strict mode snowflakes