### PR TITLE
Restore option for cluster type

### DIFF
--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraData.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraData.java
@@ -92,7 +92,8 @@ public class CassandraData {
             context.getLocalLocation(),
             context.getAccountId(),
             context.getSecretKey(),
-            context.getUsesEmc());
+            context.getUsesEmc(),
+            context.getRestoreType());
     }
 
     public static final CassandraData createBackupSnapshotStatusData() {
@@ -111,7 +112,8 @@ public class CassandraData {
             context.getLocalLocation(),
             context.getAccountId(),
             context.getSecretKey(),
-            context.getUsesEmc());
+            context.getUsesEmc(),
+            context.getRestoreType());
     }
 
     public static final CassandraData createBackupUploadStatusData() {
@@ -131,7 +133,8 @@ public class CassandraData {
             context.getLocalLocation(),
             context.getAccountId(),
             context.getSecretKey(),
-            context.getUsesEmc());
+            context.getUsesEmc(),
+            context.getRestoreType());
     }
 
     public static final CassandraData createSnapshotDownloadStatusData() {
@@ -150,7 +153,8 @@ public class CassandraData {
             context.getLocalLocation(),
             context.getAccountId(),
             context.getSecretKey(),
-            context.getUsesEmc());
+            context.getUsesEmc(),
+            context.getRestoreType());
     }
 
     public static final CassandraData createRestoreSnapshotStatusData() {
@@ -241,7 +245,8 @@ public class CassandraData {
                           final String localLocation,
                           final String accountId,
                           final String secretKey,
-                          final boolean usesEmc) {
+                          final boolean usesEmc,
+                          final String restoreType) {
 
         data = CassandraProtos.CassandraData.newBuilder()
             .setType(type.ordinal())
@@ -254,6 +259,7 @@ public class CassandraData {
             .setSecretKey(secretKey)
             .setState(Protos.TaskState.TASK_STAGING.ordinal())
             .setUsesEmc(usesEmc)
+            .setRestoreType(restoreType)
             .build();
 
     }
@@ -367,7 +373,8 @@ public class CassandraData {
             data.getLocalLocation(),
             data.getAccoundId(),
             data.getSecretKey(),
-            data.getUsesEmc());
+            data.getUsesEmc(),
+            data.getRestoreType());
     }
 
     public UpgradeSSTableContext getUpgradeSSTableContext() {

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/BackupRestoreContext.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/BackupRestoreContext.java
@@ -48,7 +48,9 @@ public class BackupRestoreContext implements ClusterTaskContext {
         @JsonProperty("secret_key")
         final String secretKey,
         @JsonProperty("uses_emc")
-        final boolean usesEmc) {
+        final boolean usesEmc,
+        @JsonProperty("restore_type")
+        final String restoreType) {
 
         return new BackupRestoreContext(
             nodeId,
@@ -57,7 +59,8 @@ public class BackupRestoreContext implements ClusterTaskContext {
             localLocation,
             accountId,
             secretKey,
-            usesEmc);
+            usesEmc,
+            restoreType);
     }
 
     @JsonProperty("node_id")
@@ -81,13 +84,17 @@ public class BackupRestoreContext implements ClusterTaskContext {
     @JsonProperty("uses_emc")
     private final boolean usesEmc;
 
+    @JsonProperty("restore_type")
+    private final String restoreType;
+
     public BackupRestoreContext(final String nodeId,
                                 final String name,
                                 final String externalLocation,
                                 final String localLocation,
                                 final String accountId,
                                 final String secretKey,
-                                final boolean usesEmc) {
+                                final boolean usesEmc,
+                                final String restoreType) {
         this.nodeId = nodeId;
         this.externalLocation = externalLocation;
         this.name = name;
@@ -95,6 +102,7 @@ public class BackupRestoreContext implements ClusterTaskContext {
         this.accountId = accountId;
         this.secretKey = secretKey;
         this.usesEmc = usesEmc;
+        this.restoreType = restoreType;
     }
 
     /**
@@ -168,6 +176,14 @@ public class BackupRestoreContext implements ClusterTaskContext {
         return nodeId;
     }
 
+    /**
+     * Gets the cluster setup for restoring
+     * either existing or completely new one.
+     * @return
+     */
+    @JsonProperty("restore_type")
+    public String getRestoreType() { return restoreType; }
+
     @Override
     public String toString() {
         return JsonUtils.toJsonString(this);
@@ -185,13 +201,14 @@ public class BackupRestoreContext implements ClusterTaskContext {
                 Objects.equals(getLocalLocation(),
                         that.getLocalLocation()) &&
                 Objects.equals(getAccountId(), that.getAccountId()) &&
-                Objects.equals(getSecretKey(), that.getSecretKey());
+                Objects.equals(getSecretKey(), that.getSecretKey()) &&
+                Objects.equals(getRestoreType(), that.getRestoreType());
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(getNodeId(), getName(), getExternalLocation(),
-                getLocalLocation(), getAccountId(), getSecretKey());
+                getLocalLocation(), getAccountId(), getSecretKey(), getRestoreType());
     }
 
     @JsonIgnore
@@ -203,7 +220,8 @@ public class BackupRestoreContext implements ClusterTaskContext {
             localLocation,
             accountId,
             secretKey,
-            usesEmc);
+            usesEmc,
+            restoreType);
     }
 
     @JsonIgnore
@@ -215,7 +233,8 @@ public class BackupRestoreContext implements ClusterTaskContext {
             localLocation,
             accountId,
             secretKey,
-            usesEmc);
+            usesEmc,
+            restoreType);
     }
 
     /**

--- a/cassandra-commons/src/main/proto/common.proto
+++ b/cassandra-commons/src/main/proto/common.proto
@@ -89,4 +89,6 @@ message CassandraData{
     optional string node = 16;
 
     optional bool usesEmc = 17;
+
+    optional string restoreType = 18;
 }

--- a/cassandra-executor/apache-cassandra-2.2.5/conf/cassandra-rackdc.properties
+++ b/cassandra-executor/apache-cassandra-2.2.5/conf/cassandra-rackdc.properties
@@ -1,4 +1,4 @@
 #DCOS got yo Cassandra!
-#Mon Nov 28 15:59:58 PST 2016
+#Tue Nov 29 10:56:25 PST 2016
 dc=dc1
 rack=rac1

--- a/cassandra-executor/apache-cassandra-2.2.5/conf/cassandra-rackdc.properties
+++ b/cassandra-executor/apache-cassandra-2.2.5/conf/cassandra-rackdc.properties
@@ -1,4 +1,4 @@
 #DCOS got yo Cassandra!
-#Tue Nov 15 18:00:30 PST 2016
+#Thu Nov 17 11:48:59 PST 2016
 dc=dc1
 rack=rac1

--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/backup/StorageUtil.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/backup/StorageUtil.java
@@ -20,6 +20,7 @@ public class StorageUtil {
 
   private final Set<String> SKIP_KEYSPACES = ImmutableSet.of("system");
   private final Map<String, List<String>> SKIP_COLUMN_FAMILIES = ImmutableMap.of();
+  public static final String SCHEMA_FILE = "schema.cql";
 
   /**
    * Filters unwanted keyspaces and column families

--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/tasks/RestoreSnapshot.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/tasks/RestoreSnapshot.java
@@ -119,7 +119,7 @@ public class RestoreSnapshot implements ExecutorTask {
 
                         final String columnFamilyPath = columnFamily.getAbsolutePath();
                         final List<String> command = Arrays.asList(
-                                ssTableLoaderBinary, "d", libProcessAddress, "f",
+                                ssTableLoaderBinary, "-d", libProcessAddress, "-f",
                                 cassandraYaml, columnFamilyPath);
                         LOGGER.info("Executing command: {}", command);
 

--- a/cassandra-executor/src/test/java/com/mesosphere/dcos/cassandra/executor/backup/S3StorageDriverTest.java
+++ b/cassandra-executor/src/test/java/com/mesosphere/dcos/cassandra/executor/backup/S3StorageDriverTest.java
@@ -29,7 +29,8 @@ public class S3StorageDriverTest {
                 "local-location",
                 "account-id",
                 "secret-key",
-                false);
+                false,
+                "existing");
         Assert.assertEquals(bucketName, s3StorageDriver.getBucketName(backupRestoreContext));
     }
 
@@ -43,7 +44,8 @@ public class S3StorageDriverTest {
                 "local-location",
                 "account-id",
                 "secret-key",
-                false);
+                false,
+                "existing");
         Assert.assertEquals(bucketName, s3StorageDriver.getBucketName(backupRestoreContext));
     }
 
@@ -57,7 +59,8 @@ public class S3StorageDriverTest {
                 "local-location",
                 "account-id",
                 "secret-key",
-                false);
+                false,
+                "existing");
         Assert.assertEquals(bucketName, s3StorageDriver.getBucketName(backupRestoreContext));
     }
 
@@ -71,7 +74,8 @@ public class S3StorageDriverTest {
                 "local-location",
                 "account-id",
                 "secret-key",
-                false);
+                false,
+                "existing");
         Assert.assertEquals(backupName, s3StorageDriver.getPrefixKey(backupRestoreContext));
     }
 
@@ -86,7 +90,8 @@ public class S3StorageDriverTest {
                 "local-location",
                 "account-id",
                 "secret-key",
-                false);
+                false,
+                "existing");
         Assert.assertEquals(nestedPath + "/" + backupName, s3StorageDriver.getPrefixKey(backupRestoreContext));
     }
 
@@ -100,7 +105,8 @@ public class S3StorageDriverTest {
                 "local-location",
                 "account-id",
                 "secret-key",
-                false);
+                false,
+                "existing");
         Assert.assertEquals(backupName, s3StorageDriver.getPrefixKey(backupRestoreContext));
     }
 
@@ -115,7 +121,8 @@ public class S3StorageDriverTest {
                 "local-location",
                 "account-id",
                 "secret-key",
-                false);
+                false,
+                "existing");
         Assert.assertEquals(nestedPath + "/" + backupName, s3StorageDriver.getPrefixKey(backupRestoreContext));
     }
 
@@ -128,7 +135,8 @@ public class S3StorageDriverTest {
                 "local-location",
                 "account-id",
                 "secret-key",
-                false);
+                false,
+                "existing");
         Assert.assertEquals(Constants.S3_HOSTNAME, s3StorageDriver.getEndpoint(backupRestoreContext));
     }
 
@@ -142,7 +150,8 @@ public class S3StorageDriverTest {
                 "local-location",
                 "account-id",
                 "secret-key",
-                false);
+                false,
+                "existing");
         Assert.assertEquals(endpoint, s3StorageDriver.getEndpoint(backupRestoreContext));
     }
 
@@ -156,7 +165,8 @@ public class S3StorageDriverTest {
                 "local-location",
                 "account-id",
                 "secret-key",
-                false);
+                false,
+                "existing");
         Assert.assertEquals(endpoint, s3StorageDriver.getEndpoint(backupRestoreContext));
     }
 
@@ -170,7 +180,8 @@ public class S3StorageDriverTest {
                 "local-location",
                 "account-id",
                 "secret-key",
-                false);
+                false,
+                "existing");
         Assert.assertEquals(endpoint, s3StorageDriver.getEndpoint(backupRestoreContext));
     }
 }

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/RestoreManager.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/RestoreManager.java
@@ -68,6 +68,7 @@ public class RestoreManager extends ChainedObserver implements ClusterTaskManage
         }
 
         BackupRestoreContext context = request.toContext();
+        LOGGER.info("Restore Type: {}", context.getRestoreType());
         LOGGER.info("Starting restore");
         try {
             if (isComplete()) {

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/BackupRestoreRequest.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/BackupRestoreRequest.java
@@ -31,6 +31,9 @@ public class BackupRestoreRequest implements ClusterTaskRequest {
   @JsonProperty("uses_emc")
   private Boolean usesEmc;
 
+  @JsonProperty("restore_type")
+  private String restoreType;
+
   public String getName() {
     return name;
   }
@@ -79,6 +82,10 @@ public class BackupRestoreRequest implements ClusterTaskRequest {
     this.azureKey = azureKey;
   }
 
+  public String getRestoreType() { return restoreType; }
+
+  public void setRestoreType(String restoreType) { this.restoreType = restoreType; }
+
   public boolean usesEmc() {
     if (usesEmc != null) {
       return usesEmc;
@@ -89,7 +96,8 @@ public class BackupRestoreRequest implements ClusterTaskRequest {
 
   public boolean isValid() {
     return (StringUtils.isNotBlank(name) && externalLocation != null)
-            && (isValidS3Request() || isValidAzureRequest());
+            && (isValidS3Request() || isValidAzureRequest())
+            && isValidRestoreType();
   }
 
   private boolean isValidS3Request() {
@@ -108,6 +116,10 @@ public class BackupRestoreRequest implements ClusterTaskRequest {
     return azureAccount != null && azureKey != null && externalLocation.startsWith("azure:");
   }
 
+  private boolean isValidRestoreType() {
+    return restoreType.matches("existing|new");
+  }
+
   @Override
   public String toString() {
     return "BackupRestoreRequest{" +
@@ -118,6 +130,7 @@ public class BackupRestoreRequest implements ClusterTaskRequest {
             ", azureAccount='" + azureAccount + '\'' +
             ", azureKey='" + azureKey + '\'' +
             ", usesEmc='" + usesEmc + '\'' +
+            ", restoreType='" + restoreType + '\'' +
             '}';
   }
 
@@ -140,7 +153,8 @@ public class BackupRestoreRequest implements ClusterTaskRequest {
         "", // local_location
         accountId,
         secretKey,
-        usesEmc());
+        usesEmc(),
+        getRestoreType());
   }
 
   private static boolean isAzure(String externalLocation) {

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/BackupRestoreRequest.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/BackupRestoreRequest.java
@@ -117,7 +117,7 @@ public class BackupRestoreRequest implements ClusterTaskRequest {
   }
 
   private boolean isValidRestoreType() {
-    return restoreType.matches("existing|new");
+    return restoreType == null? true: restoreType.matches("existing|new");
   }
 
   @Override

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/BackupRestoreRequest.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/BackupRestoreRequest.java
@@ -82,7 +82,13 @@ public class BackupRestoreRequest implements ClusterTaskRequest {
     this.azureKey = azureKey;
   }
 
-  public String getRestoreType() { return restoreType; }
+  public String getRestoreType() {
+    if (restoreType != null && !restoreType.isEmpty()) {
+      return restoreType;
+    } else {
+      return "existing";
+    }
+  }
 
   public void setRestoreType(String restoreType) { this.restoreType = restoreType; }
 
@@ -117,7 +123,7 @@ public class BackupRestoreRequest implements ClusterTaskRequest {
   }
 
   private boolean isValidRestoreType() {
-    return restoreType == null? true: restoreType.matches("existing|new");
+    return restoreType == null || restoreType.isEmpty() ? true: restoreType.matches("existing|new");
   }
 
   @Override

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/BackupManagerTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/BackupManagerTest.java
@@ -56,7 +56,7 @@ public class BackupManagerTest {
 
     @Test
     public void testInitialWithState() throws SerializationException {
-        final BackupRestoreContext context =  BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext context =  BackupRestoreContext.create("", "", "", "", "", "", false, "");
         when(mockState.fetchProperty(BackupManager.BACKUP_KEY)).thenReturn(
                 BackupRestoreContext.JSON_SERIALIZER.serialize(context));
         BackupManager manager = new BackupManager(mockCassandraState, mockProvider, mockState);
@@ -190,6 +190,7 @@ public class BackupManagerTest {
         request.setName("");
         request.setS3AccessKey("");
         request.setS3SecretKey("");
+        request.setRestoreType("");
         return request;
     }
 }

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/BackupSnapshotBlockTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/BackupSnapshotBlockTest.java
@@ -47,7 +47,7 @@ public class BackupSnapshotBlockTest {
     @Test
     public void testInitial() {
         Mockito.when(cassandraState.get("snapshot-node-0")).thenReturn(Optional.empty());
-        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false, "");
         final BackupSnapshotBlock backupSnapshotBlock = BackupSnapshotBlock.create(
                 "node-0",
                 cassandraState,
@@ -64,7 +64,7 @@ public class BackupSnapshotBlockTest {
         Mockito.when(mockCassandraTask.getState()).thenReturn(Protos.TaskState.TASK_FINISHED);
         Mockito.when(cassandraState.get("snapshot-node-0"))
                 .thenReturn(Optional.ofNullable(mockCassandraTask));
-        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false, "");
         final BackupSnapshotBlock backupSnapshotBlock = BackupSnapshotBlock.create(
                 "node-0",
                 cassandraState,
@@ -82,7 +82,7 @@ public class BackupSnapshotBlockTest {
         final HashMap<String, CassandraDaemonTask> map = new HashMap<>();
         map.put("node-0", null);
         Mockito.when(cassandraState.getDaemons()).thenReturn(map);
-        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false, "");
 
         final BackupSnapshotTask snapshotTask = Mockito.mock(BackupSnapshotTask.class);
         Mockito.when(snapshotTask.getSlaveId()).thenReturn("1234");
@@ -109,7 +109,7 @@ public class BackupSnapshotBlockTest {
         final HashMap<String, CassandraDaemonTask> map = new HashMap<>();
         map.put("node-0", daemonTask);
         Mockito.when(cassandraState.getDaemons()).thenReturn(map);
-        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false, "");
 
         final BackupSnapshotTask snapshotTask = Mockito.mock(BackupSnapshotTask.class);
         Mockito.when(snapshotTask.getSlaveId()).thenReturn("1234");
@@ -137,7 +137,7 @@ public class BackupSnapshotBlockTest {
         final HashMap<String, CassandraDaemonTask> map = new HashMap<>();
         map.put("node-0", daemonTask);
         Mockito.when(cassandraState.getDaemons()).thenReturn(map);
-        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false, "");
 
         final BackupSnapshotTask snapshotTask = Mockito.mock(BackupSnapshotTask.class);
         Mockito.when(snapshotTask.getSlaveId()).thenReturn("1234");

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/BackupSnapshotPhaseTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/BackupSnapshotPhaseTest.java
@@ -36,7 +36,7 @@ public class BackupSnapshotPhaseTest {
 
     @Test
     public void testCreateBlocksEmpty() {
-        final BackupRestoreContext context =  BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext context =  BackupRestoreContext.create("", "", "", "", "", "", false, "");
 
         when(cassandraState.getDaemons()).thenReturn(MapUtils.EMPTY_MAP);
         final BackupSnapshotPhase phase = new BackupSnapshotPhase(context, cassandraState, provider);
@@ -49,7 +49,7 @@ public class BackupSnapshotPhaseTest {
 
     @Test
     public void testCreateBlocksSingle() {
-        final BackupRestoreContext context =  BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext context =  BackupRestoreContext.create("", "", "", "", "", "", false, "");
 
         final CassandraDaemonTask daemonTask = Mockito.mock(CassandraDaemonTask.class);
         final HashMap<String, CassandraDaemonTask> map = new HashMap<>();

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/DownloadSnapshotBlockTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/DownloadSnapshotBlockTest.java
@@ -48,7 +48,7 @@ public class DownloadSnapshotBlockTest {
     @Test
     public void testInitial() {
         Mockito.when(cassandraState.get(DOWNLOAD_NODE_0)).thenReturn(Optional.empty());
-        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false, "");
         final DownloadSnapshotBlock backupSnapshotBlock = DownloadSnapshotBlock.create(
                 NODE_0,
                 cassandraState,
@@ -65,7 +65,7 @@ public class DownloadSnapshotBlockTest {
         Mockito.when(mockCassandraTask.getState()).thenReturn(Protos.TaskState.TASK_FINISHED);
         Mockito.when(cassandraState.get(DOWNLOAD_NODE_0))
                 .thenReturn(Optional.ofNullable(mockCassandraTask));
-        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false, "");
         final DownloadSnapshotBlock backupSnapshotBlock = DownloadSnapshotBlock.create(
                 NODE_0,
                 cassandraState,
@@ -83,7 +83,7 @@ public class DownloadSnapshotBlockTest {
         final HashMap<String, CassandraDaemonTask> map = new HashMap<>();
         map.put(NODE_0, null);
         Mockito.when(cassandraState.getDaemons()).thenReturn(map);
-        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false, "");
 
         final DownloadSnapshotTask snapshotTask = Mockito.mock(DownloadSnapshotTask.class);
         Mockito.when(snapshotTask.getSlaveId()).thenReturn("1234");
@@ -110,7 +110,7 @@ public class DownloadSnapshotBlockTest {
         final HashMap<String, CassandraDaemonTask> map = new HashMap<>();
         map.put(NODE_0, daemonTask);
         Mockito.when(cassandraState.getDaemons()).thenReturn(map);
-        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext backupRestoreContext = BackupRestoreContext.create("", "", "", "", "", "", false, "");
 
         final DownloadSnapshotTask snapshotTask = Mockito.mock(DownloadSnapshotTask.class);
         Mockito.when(snapshotTask.getSlaveId()).thenReturn("1234");

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/DownloadSnapshotPhaseTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/DownloadSnapshotPhaseTest.java
@@ -32,7 +32,7 @@ public class DownloadSnapshotPhaseTest {
 
     @Test
     public void testCreateBlocksEmpty() {
-        final BackupRestoreContext context =  BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext context =  BackupRestoreContext.create("", "", "", "", "", "", false, "");
 
         when(cassandraState.getDaemons()).thenReturn(MapUtils.EMPTY_MAP);
         final DownloadSnapshotPhase phase = new DownloadSnapshotPhase(context, cassandraState, provider);
@@ -45,7 +45,7 @@ public class DownloadSnapshotPhaseTest {
 
     @Test
     public void testCreateBlocksSingle() {
-        final BackupRestoreContext context =  BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext context =  BackupRestoreContext.create("", "", "", "", "", "", false, "");
 
         final CassandraDaemonTask daemonTask = Mockito.mock(CassandraDaemonTask.class);
         final HashMap<String, CassandraDaemonTask> map = new HashMap<>();

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/RestoreManagerTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/RestoreManagerTest.java
@@ -57,7 +57,7 @@ public class RestoreManagerTest {
 
     @Test
     public void testInitialWithState() throws SerializationException {
-        final BackupRestoreContext context =  BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext context =  BackupRestoreContext.create("", "", "", "", "", "", false, "");
         when(mockState.fetchProperty(RestoreManager.RESTORE_KEY)).thenReturn(
                 BackupRestoreContext.JSON_SERIALIZER.serialize(context));
         RestoreManager manager = new RestoreManager(mockCassandraState, mockProvider, mockState);

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/RestoreSnapshotBlockTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/RestoreSnapshotBlockTest.java
@@ -46,7 +46,7 @@ public class RestoreSnapshotBlockTest {
     @Test
     public void testInitial() {
         Mockito.when(cassandraState.get(RESTORE_NODE_0)).thenReturn(Optional.empty());
-        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false, "");
         final RestoreSnapshotBlock block = RestoreSnapshotBlock.create(
                 NODE_0,
                 cassandraState,
@@ -63,7 +63,7 @@ public class RestoreSnapshotBlockTest {
         Mockito.when(mockCassandraTask.getState()).thenReturn(Protos.TaskState.TASK_FINISHED);
         Mockito.when(cassandraState.get(RESTORE_NODE_0))
                 .thenReturn(Optional.ofNullable(mockCassandraTask));
-        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false, "");
         final RestoreSnapshotBlock block = RestoreSnapshotBlock.create(
                 NODE_0,
                 cassandraState,
@@ -81,7 +81,7 @@ public class RestoreSnapshotBlockTest {
         final HashMap<String, CassandraDaemonTask> map = new HashMap<>();
         map.put(NODE_0, null);
         Mockito.when(cassandraState.getDaemons()).thenReturn(map);
-        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false, "");
 
         final RestoreSnapshotTask task = Mockito.mock(RestoreSnapshotTask.class);
         Mockito.when(task.getSlaveId()).thenReturn("1234");
@@ -108,7 +108,7 @@ public class RestoreSnapshotBlockTest {
         final HashMap<String, CassandraDaemonTask> map = new HashMap<>();
         map.put(NODE_0, daemonTask);
         Mockito.when(cassandraState.getDaemons()).thenReturn(map);
-        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false, "");
 
         final RestoreSnapshotTask task = Mockito.mock(RestoreSnapshotTask.class);
         Mockito.when(task.getSlaveId()).thenReturn("1234");

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/UploadBackupBlockTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/plan/backup/UploadBackupBlockTest.java
@@ -46,7 +46,7 @@ public class UploadBackupBlockTest {
     @Test
     public void testInitial() {
         Mockito.when(cassandraState.get(UPLOAD_NODE_0)).thenReturn(Optional.empty());
-        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false, "");
         final UploadBackupBlock block = UploadBackupBlock.create(
                 NODE_0,
                 cassandraState,
@@ -63,7 +63,7 @@ public class UploadBackupBlockTest {
         Mockito.when(mockCassandraTask.getState()).thenReturn(Protos.TaskState.TASK_FINISHED);
         Mockito.when(cassandraState.get(UPLOAD_NODE_0))
                 .thenReturn(Optional.ofNullable(mockCassandraTask));
-        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false, "");
         final UploadBackupBlock block = UploadBackupBlock.create(
                 NODE_0,
                 cassandraState,
@@ -81,7 +81,7 @@ public class UploadBackupBlockTest {
         final HashMap<String, CassandraDaemonTask> map = new HashMap<>();
         map.put(NODE_0, null);
         Mockito.when(cassandraState.getDaemons()).thenReturn(map);
-        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false, "");
 
         final BackupUploadTask task = Mockito.mock(BackupUploadTask.class);
         Mockito.when(task.getSlaveId()).thenReturn("1234");
@@ -108,7 +108,7 @@ public class UploadBackupBlockTest {
         final HashMap<String, CassandraDaemonTask> map = new HashMap<>();
         map.put(NODE_0, daemonTask);
         Mockito.when(cassandraState.getDaemons()).thenReturn(map);
-        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false);
+        final BackupRestoreContext context = BackupRestoreContext.create("", "", "", "", "", "", false, "");
 
         final BackupUploadTask task = Mockito.mock(BackupUploadTask.class);
         Mockito.when(task.getSlaveId()).thenReturn("1234");


### PR DESCRIPTION
For restore, added a new option to restore on existing cluster with same token range or a completely new cluster bootstrapped from scratch. For same cluster, use nodetool refresh to restore data and for new cluster use sstableloader. Difference is due to the significant performance disparity.