### PR TITLE
Added upgrade test

### DIFF
--- a/integration/tests/command.py
+++ b/integration/tests/command.py
@@ -78,8 +78,25 @@ def get_dcos_command(command):
     return result
 
 
+@as_json
+def get_cassandra_command(command):
+    result, error = shakedown.run_dcos_command(
+        '{} {}'.format(PACKAGE_NAME, command)
+    )
+    if error:
+        raise RuntimeError(
+            'command dcos {} {} failed'.format(command, PACKAGE_NAME)
+        )
+
+    return result
+
+
 def marathon_api_url(basename):
     return '{}/v2/{}'.format(shakedown.dcos_service_url('marathon'), basename)
+
+
+def marathon_api_url_with_param(basename, path_param):
+    return '{}/{}'.format(marathon_api_url(basename), path_param)
 
 
 def request(request_fn, *args, **kwargs):
@@ -111,10 +128,13 @@ def spin(fn, success_predicate, *args, **kwargs):
     return result
 
 
-def install(additional_options = {}):
+def install(additional_options = {}, package_version = None):
     merged_options = _nested_dict_merge(DEFAULT_OPTIONS_DICT, additional_options)
     print('Installing {} with options: {}'.format(PACKAGE_NAME, merged_options))
-    shakedown.install_package_and_wait(PACKAGE_NAME, options_json=merged_options)
+    shakedown.install_package_and_wait(
+        PACKAGE_NAME,
+        package_version,
+        options_json=merged_options)
 
 
 def uninstall():

--- a/integration/tests/test_upgrade.py
+++ b/integration/tests/test_upgrade.py
@@ -1,0 +1,116 @@
+import dcos.http
+import pytest
+import shakedown
+
+
+from . import infinity_commons
+
+from tests.command import (
+    check_health,
+    get_cassandra_command,
+    get_dcos_command,
+    install,
+    marathon_api_url_with_param,
+    request,
+    spin,
+    uninstall,
+)
+
+from tests.defaults import DEFAULT_NODE_COUNT, PACKAGE_NAME
+
+def setup_module(module):
+    uninstall()
+
+
+def teardown_module(module):
+    uninstall()
+
+
+@pytest.mark.sanity
+def test_upgrade():
+    test_repo_name, test_repo_url = get_test_repo_info()
+    test_version = get_pkg_version()
+    print('Found test version: {}'.format(test_version))
+    remove_repo(test_repo_name, test_version)
+    master_version = get_pkg_version()
+    print('Found master version: {}'.format(master_version))
+
+    print('Installing master version')
+    install(package_version = master_version)
+    check_health()
+    infinity_commons.get_and_verify_plan(lambda p: p['status'] == infinity_commons.PlanState.COMPLETE.value)
+    # TODO: write some data
+
+    print('Upgrading to test version')
+    destroy_service()
+    add_repo(test_repo_name, test_repo_url, master_version)
+    install(package_version = test_version)
+    check_post_upgrade_health()
+
+
+def get_test_repo_info():
+    repos = shakedown.get_package_repos()
+    test_repo = repos['repositories'][0]
+    return test_repo['name'], test_repo['uri']
+
+
+def get_pkg_version():
+    cmd = 'package describe {}'.format(PACKAGE_NAME)
+    pkg_description = get_dcos_command(cmd)
+    return pkg_description['version']
+
+
+def remove_repo(repo_name, prev_version):
+    assert shakedown.remove_package_repo(repo_name)
+    new_default_version_available(prev_version)
+
+
+def add_repo(repo_name, repo_url, prev_version):
+    assert shakedown.add_package_repo(
+        repo_name,
+        repo_url,
+        0)
+    # Make sure the new repo packages are available
+    new_default_version_available(prev_version)
+
+
+def new_default_version_available(prev_version):
+    def fn():
+        get_pkg_version()
+    def success_predicate(pkg_version):
+        return (pkg_version != prev_version, 'Package version has not changed')
+    spin(fn, success_predicate)
+
+
+def destroy_service():
+    destroy_endpoint = marathon_api_url_with_param('apps', PACKAGE_NAME)
+    request(dcos.http.delete, destroy_endpoint)
+    # Make sure the scheduler has been destroyed
+    def fn():
+        shakedown.get_service(PACKAGE_NAME)
+
+    def success_predicate(service):
+        return (service == None, 'Service not destroyed')
+
+    spin(fn, success_predicate)
+
+
+def check_post_upgrade_health():
+    check_health()
+    check_scheduler_health()
+    # TODO: verify data integrity
+
+
+def check_scheduler_health():
+    # Make sure scheduler endpoint is responding and all nodes are available
+    def fn():
+        try:
+            return get_cassandra_command('node list')
+        except RuntimeError:
+            return []
+
+    def success_predicate(brokers):
+        return (len(brokers) == DEFAULT_NODE_COUNT,
+                'Scheduler and all nodes not available')
+
+    spin(fn, success_predicate)


### PR DESCRIPTION
0. - (After normal test tools have already automatically added the infinity-artifacts stub universe...)
1. - Remove the infinity-artifacts custom universe added automatically by test tools (and keep the URL handy for re-adding below)
2. - Install framework universe build
3. - Re-add infinity-artifacts custom universe at index 0
4. - Upgrade framework to infinity-artifacts build
5. - Verify that rollout occurred as expected, and that upgraded framework is healthy

TODO: the data integrity check is still missing. There's currently no easy way to write/read some rows in Cassandra via shakedown. I would like to add something similar to what Kafka has (a test producer endpoint), but address it in a separate PR.