### PR TITLE
Drain the Cassandra node that we are trying to kill so that the it shuts down gracefully and clients do not receive timeout exceptions

### DIFF
--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraState.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraState.java
@@ -68,13 +68,13 @@ public class CassandraState extends SchedulerState implements Managed {
         // retrieval of tasks
         try {
             synchronized (getStateStore()) {
-                LOGGER.info("Loading data from persistent store");
+                LOGGER.debug("Loading data from persistent store");
                 final Collection<Protos.TaskInfo> taskInfos = getStateStore().fetchTasks();
 
                 for (Protos.TaskInfo taskInfo : taskInfos) {
                     try {
                         final CassandraTask cassandraTask = CassandraTask.parse(TaskUtils.unpackTaskInfo(taskInfo));
-                        LOGGER.info("Loaded task: {}, type: {}, hostname: {}",
+                        LOGGER.debug("Loaded task: {}, type: {}, hostname: {}",
                                 cassandraTask.getName(), cassandraTask.getType().name(), cassandraTask.getHostname());
                         builder.put(cassandraTask.getName(), cassandraTask);
                     } catch (IOException e) {

--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/CassandraDaemonProcess.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/CassandraDaemonProcess.java
@@ -35,6 +35,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -195,6 +196,21 @@ public class CassandraDaemonProcess extends ProcessTask {
                         open,
                         mode),
                 1, 1, TimeUnit.SECONDS);
+    }
+
+    // Override the stop function of ProcessTask to drain the Cassandra node before killing it.
+    @Override
+    public void stop(Future<?> future) {
+        try {
+            // Drain the Cassandra node that we are trying to kill so that the it shuts down gracefully
+            // and clients do not receive timeout exceptions.
+            LOGGER.info("Draining cassandra node before killing it");
+            drain();
+        } catch (InterruptedException | ExecutionException | IOException e) {
+            e.printStackTrace();
+        }
+
+        super.stop(future);
     }
 
     private static String getReplaceIp(CassandraDaemonTask cassandraDaemonTask) throws UnknownHostException {

--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/CassandraDaemonProcess.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/CassandraDaemonProcess.java
@@ -202,7 +202,7 @@ public class CassandraDaemonProcess extends ProcessTask {
     @Override
     public void stop(Future<?> future) {
         try {
-            // Drain the Cassandra node that we are trying to kill so that the it shuts down gracefully
+            // Drain the Cassandra node that we are trying to kill so that it shuts down gracefully
             // and clients do not receive timeout exceptions.
             LOGGER.info("Draining cassandra node before killing it");
             drain();

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonStep.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonStep.java
@@ -152,7 +152,7 @@ public class CassandraDaemonStep extends DefaultStep {
         try {
             final String taskName = org.apache.mesos.offer.TaskUtils.toTaskName(status.getTaskId());
             if (!getName().equals(taskName)) {
-                LOGGER.info("TaskStatus was meant for step: {} and doesn't affect step {}. Status: {}",
+                LOGGER.debug("TaskStatus was meant for step: {} and doesn't affect step {}. Status: {}",
                         taskName, getName(), TextFormat.shortDebugString(status));
                 return;
             }


### PR DESCRIPTION
Also change some info logs to debug to decrease verbosity.