### PR TITLE
Consume mesos 1.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ configure(subprojects - project('seedprovider')) {
     ext {
         dropwizardVer = '0.9.2'
         guiceVer = '4.0'
-        mesosVer = '0.28.1'
+        mesosVer = '1.0.2'
         junitVer = '4.12'
         guavaVer = '19.0'
         slf4jVer = '1.7.14'

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/ExecutorConfig.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/ExecutorConfig.java
@@ -26,7 +26,8 @@ public class ExecutorConfig {
             String javaHome,
             URI jreLocation,
             URI executorLocation,
-            URI cassandraLocation) {
+            URI cassandraLocation,
+            URI libmesosLocation) {
 
         return new ExecutorConfig(
                 command,
@@ -38,7 +39,8 @@ public class ExecutorConfig {
                 javaHome,
                 jreLocation,
                 executorLocation,
-                cassandraLocation);
+                cassandraLocation,
+                libmesosLocation);
     }
 
     @JsonCreator
@@ -53,6 +55,7 @@ public class ExecutorConfig {
             @JsonProperty("jre_location") String jreLocation,
             @JsonProperty("executor_location") String executorLocation,
             @JsonProperty("cassandra_location") String cassandraLocation,
+            @JsonProperty("libmesos_location") String libmesosLocation,
             @JsonProperty("emc_ecs_workaround") boolean emcEcsWorkaround)
             throws URISyntaxException, UnsupportedEncodingException {
 
@@ -66,7 +69,8 @@ public class ExecutorConfig {
                 javaHome,
                 URI.create(jreLocation),
                 URI.create(executorLocation),
-                URI.create(cassandraLocation));
+                URI.create(cassandraLocation),
+                URI.create(libmesosLocation));
 
         return config;
     }
@@ -92,6 +96,7 @@ public class ExecutorConfig {
     private final URI jreLocation;
     private final URI executorLocation;
     private final URI cassandraLocation;
+    private final URI libmesosLocation;
 
     @JsonProperty("java_home")
     private final String javaHome;
@@ -106,7 +111,8 @@ public class ExecutorConfig {
             String javaHome,
             URI jreLocation,
             URI executorLocation,
-            URI cassandraLocation) {
+            URI cassandraLocation,
+            URI libmesosLocation) {
 
         this.command = command;
         this.arguments = arguments;
@@ -117,6 +123,7 @@ public class ExecutorConfig {
         this.jreLocation = jreLocation;
         this.executorLocation = executorLocation;
         this.cassandraLocation = cassandraLocation;
+        this.libmesosLocation = libmesosLocation;
         this.javaHome = javaHome;
     }
 
@@ -157,6 +164,10 @@ public class ExecutorConfig {
         return jreLocation;
     }
 
+    public URI getLibmesosLocation() {
+        return libmesosLocation;
+    }
+
     public int getMemoryMb() {
         return memoryMb;
     }
@@ -176,12 +187,19 @@ public class ExecutorConfig {
         return cassandraLocation.toString();
     }
 
+    @JsonProperty("libmesos_location")
+    public String getLibmesosLocationString() {
+        return libmesosLocation.toString();
+    }
+
+
     @JsonIgnore
     public Set<String> getURIs() {
         Set<String> uris = new HashSet<String>();
         uris.add(executorLocation.toString());
         uris.add(cassandraLocation.toString());
         uris.add(jreLocation.toString());
+        uris.add(libmesosLocation.toString());
 
         return uris;
     }

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/ExecutorConfig.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/ExecutorConfig.java
@@ -220,6 +220,8 @@ public class ExecutorConfig {
                         that.getExecutorLocation()) &&
                 Objects.equals(getCassandraLocation(),
                         that.getCassandraLocation()) &&
+                Objects.equals(getLibmesosLocation(),
+                        that.getLibmesosLocation()) &&
                 Objects.equals(getJavaHome(), that.getJavaHome());
     }
 
@@ -228,7 +230,7 @@ public class ExecutorConfig {
         return Objects.hash(getCommand(), getArguments(), getCpus(),
                 getMemoryMb(),
                 getHeapMb(), getApiPort(),
-                getJreLocation(), getExecutorLocation(), getCassandraLocation(),
+                getJreLocation(), getExecutorLocation(), getCassandraLocation(), getLibmesosLocation(),
                 getJavaHome());
     }
 

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/ExecutorConfig.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/ExecutorConfig.java
@@ -127,7 +127,7 @@ public class ExecutorConfig {
         this.javaHome = javaHome;
     }
 
-
+    @JsonIgnore
     public int getApiPort() {
         return apiPort;
     }
@@ -136,6 +136,7 @@ public class ExecutorConfig {
         return arguments;
     }
 
+    @JsonIgnore
     public URI getCassandraLocation() {
         return cassandraLocation;
     }
@@ -148,6 +149,7 @@ public class ExecutorConfig {
         return cpus;
     }
 
+    @JsonIgnore
     public URI getExecutorLocation() {
         return executorLocation;
     }
@@ -160,10 +162,12 @@ public class ExecutorConfig {
         return javaHome;
     }
 
+    @JsonIgnore
     public URI getJreLocation() {
         return jreLocation;
     }
 
+    @JsonIgnore
     public URI getLibmesosLocation() {
         return libmesosLocation;
     }

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/MutableSchedulerConfiguration.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/MutableSchedulerConfiguration.java
@@ -2,9 +2,11 @@ package com.mesosphere.dcos.cassandra.common.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mesosphere.dcos.cassandra.common.util.JsonUtils;
 import io.dropwizard.Configuration;
 
-import java.util.*;
+import java.util.Objects;
+import java.util.Optional;
 
 public class MutableSchedulerConfiguration extends Configuration {
 
@@ -236,5 +238,10 @@ public class MutableSchedulerConfiguration extends Configuration {
     return Objects.hash(executorConfig, servers, seeds, placementConstraint, cassandraConfig,
       clusterTaskConfig, apiPort, serviceConfig, mesosConfig, curatorConfig,
       externalDcSyncMs, externalDcs, dcUrl, enableUpgradeSSTableEndpoint);
+  }
+
+  @Override
+  public String toString() {
+    return JsonUtils.toJsonString(this);
   }
 }

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraTaskExecutor.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraTaskExecutor.java
@@ -116,10 +116,12 @@ public class CassandraTaskExecutor {
                 arguments,
                 uris,
                 ImmutableMap.<String, String>builder()
-                    .put("JAVA_HOME", javaHome)
-                    .put("JAVA_OPTS", "-Xmx" + heapMb + "M")
-                    .put("EXECUTOR_API_PORT", Integer.toString(apiPort))
-                    .build()))
+                        .put("LD_LIBRARY_PATH", "$MESOS_SANDBOX/libmesos-bundle/lib")
+                        .put("MESOS_NATIVE_JAVA_LIBRARY", "$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so)")
+                        .put("JAVA_HOME", javaHome)
+                        .put("JAVA_OPTS", "-Xmx" + heapMb + "M")
+                        .put("EXECUTOR_API_PORT", Integer.toString(apiPort))
+                        .build()))
             .addAllResources(
                 Arrays.asList(
                     createCpus(cpus, role, principal),
@@ -254,6 +256,8 @@ public class CassandraTaskExecutor {
                         config.getArguments(),
                         config.getURIs(),
                         ImmutableMap.<String, String>builder()
+                                .put("LD_LIBRARY_PATH", "$MESOS_SANDBOX/libmesos-bundle/lib")
+                                .put("MESOS_NATIVE_JAVA_LIBRARY", "$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so)")
                                 .put("JAVA_HOME", config.getJavaHome())
                                 .put("JAVA_OPTS", "-Xmx" + config.getHeapMb() + "M")
                                 .put("EXECUTOR_API_PORT", Integer.toString(config.getApiPort()))

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraTaskExecutor.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraTaskExecutor.java
@@ -116,8 +116,6 @@ public class CassandraTaskExecutor {
                 arguments,
                 uris,
                 ImmutableMap.<String, String>builder()
-                        .put("LD_LIBRARY_PATH", "$MESOS_SANDBOX/libmesos-bundle/lib")
-                        .put("MESOS_NATIVE_JAVA_LIBRARY", "$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so)")
                         .put("JAVA_HOME", javaHome)
                         .put("JAVA_OPTS", "-Xmx" + heapMb + "M")
                         .put("EXECUTOR_API_PORT", Integer.toString(apiPort))
@@ -256,8 +254,6 @@ public class CassandraTaskExecutor {
                         config.getArguments(),
                         config.getURIs(),
                         ImmutableMap.<String, String>builder()
-                                .put("LD_LIBRARY_PATH", "$MESOS_SANDBOX/libmesos-bundle/lib")
-                                .put("MESOS_NATIVE_JAVA_LIBRARY", "$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so)")
                                 .put("JAVA_HOME", config.getJavaHome())
                                 .put("JAVA_OPTS", "-Xmx" + config.getHeapMb() + "M")
                                 .put("EXECUTOR_API_PORT", Integer.toString(config.getApiPort()))

--- a/cassandra-commons/src/test/java/com/mesosphere/dcos/cassandra/common/config/ConfigurationManagerTest.java
+++ b/cassandra-commons/src/test/java/com/mesosphere/dcos/cassandra/common/config/ConfigurationManagerTest.java
@@ -158,7 +158,8 @@ public class ConfigurationManagerTest {
                 17,
                 "/java/home",
                 URI.create("/jre/location"), URI.create("/executor/location"),
-                URI.create("/cassandra/location"));
+                URI.create("/cassandra/location"),
+                URI.create("/libmesos/location"));
         int updatedServers = original.getServers() + 10;
         int updatedSeeds = original.getSeeds() + 5;
 

--- a/cassandra-commons/src/test/java/com/mesosphere/dcos/cassandra/common/config/ConfigurationManagerTest.java
+++ b/cassandra-commons/src/test/java/com/mesosphere/dcos/cassandra/common/config/ConfigurationManagerTest.java
@@ -24,7 +24,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.io.File;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
@@ -169,7 +171,6 @@ public class ConfigurationManagerTest {
                         new EnvironmentVariableSubstitutor(false, true)),
                 Resources.getResource("scheduler.yml").getFile());
 
-
         mutable.setSeeds(updatedSeeds);
         mutable.setServers(updatedServers);
         mutable.setExecutorConfig(updatedExecutorConfig);
@@ -200,6 +201,69 @@ public class ConfigurationManagerTest {
         assertEquals(updatedServers, targetConfig.getServers());
 
         assertEquals(updatedSeeds, targetConfig.getSeeds());
+    }
+
+    @Test
+    public void serializeDeserializeExecutorConfig() throws Exception {
+        MutableSchedulerConfiguration mutable = configurationFactory.build(
+                new SubstitutingSourceProvider(
+                        new FileConfigurationSourceProvider(),
+                        new EnvironmentVariableSubstitutor(false, true)),
+                Resources.getResource("scheduler.yml").getFile());
+        final CassandraSchedulerConfiguration original = mutable.createConfig();
+        final CuratorFrameworkConfig curatorConfig = mutable.getCuratorConfig();
+
+        mutable.setCassandraConfig(
+                mutable.getCassandraConfig()
+                        .mutable().setJmxPort(8000).setCpus(0.6).setMemoryMb(10000).build());
+
+        RetryPolicy retryPolicy =
+                (curatorConfig.getOperationTimeout().isPresent()) ?
+                        new RetryUntilElapsed(
+                                curatorConfig.getOperationTimeoutMs()
+                                        .get()
+                                        .intValue()
+                                , (int) curatorConfig.getBackoffMs()) :
+                        new RetryForever((int) curatorConfig.getBackoffMs());
+
+        StateStore stateStore = new CuratorStateStore(
+                original.getServiceConfig().getName(),
+                server.getConnectString(),
+                retryPolicy);
+
+        DefaultConfigurationManager configurationManager =
+                new DefaultConfigurationManager(CassandraSchedulerConfiguration.class,
+                        original.getServiceConfig().getName(),
+                        connectString,
+                        original,
+                        new ConfigValidator(),
+                        stateStore);
+
+        configurationManager.store(original);
+        ConfigurationManager manager = new ConfigurationManager(taskFactory, configurationManager);
+        CassandraSchedulerConfiguration targetConfig =
+                (CassandraSchedulerConfiguration)configurationManager.getTargetConfig();
+
+        ExecutorConfig expectedExecutorConfig = new ExecutorConfig(
+                "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib && export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && ./executor/bin/cassandra-executor server executor/conf/executor.yml",
+                new ArrayList<>(),
+                0.1,
+                768,
+                512,
+                9000,
+                "./jre",
+                URI.create("https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/jre/linux/server-jre-8u74-linux-x64.tar.gz"),
+                URI.create("https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/executor.zip"),
+                URI.create("https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/apache-cassandra-2.2.5-bin.tar.gz"),
+                URI.create("http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.bz2"));
+
+        manager.start();
+
+        assertEquals(original.getCassandraConfig(), targetConfig.getCassandraConfig());
+
+        assertEquals(expectedExecutorConfig, targetConfig.getExecutorConfig());
+
+        manager.stop();
     }
 
     @Test

--- a/cassandra-commons/src/test/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraDaemonTaskTest.java
+++ b/cassandra-commons/src/test/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraDaemonTaskTest.java
@@ -45,7 +45,8 @@ public class CassandraDaemonTaskTest {
                 "java-home",
                 new URI("http://jre-location"),
                 new URI("http://executor-location"),
-                new URI("http://cassandra-location"));
+                new URI("http://cassandra-location"),
+                new URI("http://libmesos-location"));
 
         testTaskExecutor = CassandraTaskExecutor.create(
                 "test-framework-id",
@@ -196,7 +197,8 @@ public class CassandraDaemonTaskTest {
                 "java-home",
                 new URI("http://jre-location"),
                 new URI("http://executor-location"),
-                new URI("http://cassandra-location-updated"));
+                new URI("http://cassandra-location-updated"),
+                new URI("http://libmesos-location"));
 
         testTaskExecutor = CassandraTaskExecutor.create(
                 "test-framework-id",
@@ -210,7 +212,7 @@ public class CassandraDaemonTaskTest {
                 updatedTestExecutorConfig,
                 TEST_CONFIG_ID);
         Assert.assertNotEquals(normalizeCassandraTaskInfo(daemonTask), normalizeCassandraTaskInfo(updatedTask));
-        Assert.assertEquals(3, updatedTask.getExecutor().getURIs().size());
+        Assert.assertEquals(4, updatedTask.getExecutor().getURIs().size());
         Assert.assertTrue(updatedTask.getExecutor().getURIs().contains("http://cassandra-location-updated"));
     }
 

--- a/cassandra-commons/src/test/resources/scheduler.yml
+++ b/cassandra-commons/src/test/resources/scheduler.yml
@@ -1,5 +1,5 @@
 executor:
-  command : ${EXECUTOR_COMMAND:-"./executor/bin/cassandra-executor server executor/conf/executor.yml"}
+  command : ${EXECUTOR_COMMAND:-"export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib && export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && ./executor/bin/cassandra-executor server executor/conf/executor.yml"}
   arguments : ${EXECUTOR_ARGS:-[]}
   cpus : ${EXECUTOR_CPUS:-0.1}
   memory_mb : ${EXECUTOR_MEMORY_MB:-768}
@@ -9,6 +9,7 @@ executor:
   jre_location : ${EXECUTOR_JRE_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/jre/linux/server-jre-8u74-linux-x64.tar.gz'}
   executor_location : ${EXECUTOR_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/executor.zip'}
   cassandra_location : ${EXECUTOR_CASSANDRA_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/apache-cassandra-2.2.5-bin.tar.gz'}
+  libmesos_location: ${EXECUTOR_LIBMESOS_LOCATION:-'http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.bz2'}
 cluster_task:
   cpus: ${CLUSTER_TASK_CPUS:-1}
   memory_mb: ${CLUSTER_TASK_MEMORY_MB:-256}

--- a/cassandra-executor/apache-cassandra-2.2.5/conf/cassandra-rackdc.properties
+++ b/cassandra-executor/apache-cassandra-2.2.5/conf/cassandra-rackdc.properties
@@ -1,4 +1,4 @@
 #DCOS got yo Cassandra!
-#Mon Dec 05 14:06:38 PST 2016
+#Wed Dec 14 14:25:31 PST 2016
 dc=dc1
 rack=rac1

--- a/cassandra-executor/src/test/resources/scheduler.yml
+++ b/cassandra-executor/src/test/resources/scheduler.yml
@@ -1,5 +1,5 @@
 executor:
-  command : ${EXECUTOR_COMMAND:-"./executor/bin/cassandra-executor server executor/conf/executor.yml"}
+  command : ${EXECUTOR_COMMAND:-"export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib && export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && ./executor/bin/cassandra-executor server executor/conf/executor.yml"}
   arguments : ${EXECUTOR_ARGS:-[]}
   cpus : ${EXECUTOR_CPUS:-0.1}
   memory_mb : ${EXECUTOR_MEMORY_MB:-768}
@@ -9,6 +9,7 @@ executor:
   jre_location : ${EXECUTOR_JRE_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/jre/linux/server-jre-8u74-linux-x64.tar.gz'}
   executor_location : ${EXECUTOR_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/executor.zip'}
   cassandra_location : ${EXECUTOR_CASSANDRA_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/apache-cassandra-2.2.5-bin.tar.gz'}
+  libmesos_location: ${EXECUTOR_LIBMESOS_LOCATION:-'http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.bz2'}
 cluster_task:
   cpus: ${CLUSTER_TASK_CPUS:-1}
   memory_mb: ${CLUSTER_TASK_MEMORY_MB:-256}

--- a/cassandra-scheduler/src/dist/conf/scheduler.yml
+++ b/cassandra-scheduler/src/dist/conf/scheduler.yml
@@ -1,5 +1,5 @@
 executor:
-  command : ${EXECUTOR_COMMAND:-"./executor/bin/cassandra-executor server executor/conf/executor.yml"}
+  command : ${EXECUTOR_COMMAND:-"export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib && export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && ./executor/bin/cassandra-executor server executor/conf/executor.yml"}
   arguments : ${EXECUTOR_ARGS:-[]}
   cpus : ${EXECUTOR_CPUS:-0.1}
   memory_mb : ${EXECUTOR_MEMORY_MB:-768}
@@ -9,6 +9,7 @@ executor:
   jre_location : ${EXECUTOR_JRE_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/jre/linux/server-jre-8u74-linux-x64.tar.gz'}
   executor_location : ${EXECUTOR_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/executor.zip'}
   cassandra_location : ${EXECUTOR_CASSANDRA_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/apache-cassandra-2.2.5-bin.tar.gz'}
+  libmesos_location: ${EXECUTOR_LIBMESOS_LOCATION:-'http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.bz2'}
 cluster_task:
   cpus: ${CLUSTER_TASK_CPUS:-1}
   memory_mb: ${CLUSTER_TASK_MEMORY_MB:-256}

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/Main.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/Main.java
@@ -93,6 +93,7 @@ public class Main extends Application<MutableSchedulerConfiguration> {
 
 
   private void logConfiguration(MutableSchedulerConfiguration config) {
+    LOGGER.info("Full configuration: {}", config);
 
     LOGGER.info("Framework ServiceConfig = {}",
       config.getServiceConfig());

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/common/offer/ClusterTaskOfferRequirementProviderTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/common/offer/ClusterTaskOfferRequirementProviderTest.java
@@ -234,16 +234,19 @@ public class ClusterTaskOfferRequirementProviderTest {
         final Protos.ExecutorInfo executorInfo = requirement.getExecutorRequirementOptional().get().getExecutorInfo();
 
         Protos.CommandInfo cmd = executorInfo.getCommand();
-        Assert.assertEquals(3, cmd.getUrisList().size());
+        Assert.assertEquals(4, cmd.getUrisList().size());
         Assert.assertEquals(
             config.getExecutorConfig().getExecutorLocation().toString(),
             cmd.getUrisList().get(0).getValue());
         Assert.assertEquals(
+                config.getExecutorConfig().getLibmesosLocation().toString(),
+                cmd.getUrisList().get(1).getValue());
+        Assert.assertEquals(
             config.getExecutorConfig().getCassandraLocation().toString(),
-            cmd.getUrisList().get(1).getValue());
+            cmd.getUrisList().get(2).getValue());
         Assert.assertEquals(
             config.getExecutorConfig().getJreLocation().toString(),
-            cmd.getUrisList().get(2).getValue());
+            cmd.getUrisList().get(3).getValue());
     }
 
     @Test

--- a/cassandra-scheduler/src/test/resources/scheduler.yml
+++ b/cassandra-scheduler/src/test/resources/scheduler.yml
@@ -1,5 +1,5 @@
 executor:
-  command : ${EXECUTOR_COMMAND:-"./executor/bin/cassandra-executor server executor/conf/executor.yml"}
+  command : ${EXECUTOR_COMMAND:-"export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib && export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && ./executor/bin/cassandra-executor server executor/conf/executor.yml"}
   arguments : ${EXECUTOR_ARGS:-[]}
   cpus : ${EXECUTOR_CPUS:-0.1}
   memory_mb : ${EXECUTOR_MEMORY_MB:-768}
@@ -9,6 +9,7 @@ executor:
   jre_location : ${EXECUTOR_JRE_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/jre/linux/server-jre-8u74-linux-x64.tar.gz'}
   executor_location : ${EXECUTOR_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/executor.zip'}
   cassandra_location : ${EXECUTOR_CASSANDRA_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/apache-cassandra-2.2.5-bin.tar.gz'}
+  libmesos_location: ${EXECUTOR_LIBMESOS_LOCATION:-'http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.bz2'}
 cluster_task:
   cpus: ${CLUSTER_TASK_CPUS:-1}
   memory_mb: ${CLUSTER_TASK_MEMORY_MB:-256}

--- a/cassandra-scheduler/src/test/resources/update-scheduler.yml
+++ b/cassandra-scheduler/src/test/resources/update-scheduler.yml
@@ -1,5 +1,5 @@
 executor:
-  command : ${EXECUTOR_COMMAND:-"./executor/bin/cassandra-executor server executor/conf/executor.yml"}
+  command : ${EXECUTOR_COMMAND:-"export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib && export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) &&  ./executor/bin/cassandra-executor server executor/conf/executor.yml"}
   arguments : ${EXECUTOR_ARGS:-[]}
   cpus : ${EXECUTOR_CPUS:-0.1}
   memory_mb : ${EXECUTOR_MEMORY_MB:-768}
@@ -9,6 +9,7 @@ executor:
   jre_location : ${EXECUTOR_JRE_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/jre/linux/server-jre-8u74-linux-x64.tar.gz'}
   executor_location : ${EXECUTOR_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/executor.zip'}
   cassandra_location : ${EXECUTOR_CASSANDRA_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/apache-cassandra-2.2.5-bin-updated.tar.gz'}
+  libmesos_location: ${EXECUTOR_LIBMESOS_LOCATION:-'http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.bz2'}
 cluster_task:
   cpus: ${CLUSTER_TASK_CPUS:-1}
   memory_mb: ${CLUSTER_TASK_MEMORY_MB:-256}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jul 11 16:19:49 PDT 2016
+#Tue Dec 06 15:07:33 PST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip

--- a/integration/tests/command.py
+++ b/integration/tests/command.py
@@ -22,7 +22,8 @@ def as_json(fn):
     def wrapper(*args, **kwargs):
         try:
             return json.loads(fn(*args, **kwargs))
-        except ValueError:
+        except ValueError as e:
+            print("ValueError: {}".format(e))
             return None
 
     return wrapper
@@ -69,26 +70,26 @@ def get_cassandra_config():
 
 @as_json
 def get_dcos_command(command):
-    result, error = shakedown.run_dcos_command(command)
-    if error:
+    stdout, _, rc = shakedown.run_dcos_command(command)
+    if rc:
         raise RuntimeError(
             'command dcos {} {} failed'.format(command, PACKAGE_NAME)
         )
 
-    return result
+    return stdout
 
 
 @as_json
 def get_cassandra_command(command):
-    result, error = shakedown.run_dcos_command(
+    stdout, _, rc = shakedown.run_dcos_command(
         '{} {}'.format(PACKAGE_NAME, command)
     )
-    if error:
+    if rc:
         raise RuntimeError(
             'command dcos {} {} failed'.format(command, PACKAGE_NAME)
         )
 
-    return result
+    return stdout 
 
 
 def marathon_api_url(basename):

--- a/integration/tests/command.py
+++ b/integration/tests/command.py
@@ -70,10 +70,10 @@ def get_cassandra_config():
 
 @as_json
 def get_dcos_command(command):
-    stdout, _, rc = shakedown.run_dcos_command(command)
+    stdout, stderr, rc = shakedown.run_dcos_command(command)
     if rc:
         raise RuntimeError(
-            'command dcos {} {} failed'.format(command, PACKAGE_NAME)
+            'command dcos {} {} failed: {} {}'.format(command, PACKAGE_NAME, stdout, stderr)
         )
 
     return stdout
@@ -81,12 +81,12 @@ def get_dcos_command(command):
 
 @as_json
 def get_cassandra_command(command):
-    stdout, _, rc = shakedown.run_dcos_command(
+    stdout, stderr, rc = shakedown.run_dcos_command(
         '{} {}'.format(PACKAGE_NAME, command)
     )
     if rc:
         raise RuntimeError(
-            'command dcos {} {} failed'.format(command, PACKAGE_NAME)
+            'command dcos {} {} failed: {} {}'.format(command, PACKAGE_NAME, stdout, stderr)
         )
 
     return stdout 

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -1,7 +1,7 @@
 
 {
   "id": "/{{service.name}}",
-  "cmd": "./scheduler/bin/cassandra-scheduler server ./scheduler/conf/scheduler.yml",
+  "cmd": "env && export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib && export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && env && ./scheduler/bin/cassandra-scheduler server ./scheduler/conf/scheduler.yml",
   "instances": 1,
   "cpus": {{service.cpus}},
   "mem": {{service.mem}},
@@ -16,7 +16,8 @@
   ],
 "uris": [
   "{{resource.assets.uris.scheduler-zip}}",
-  "{{resource.assets.uris.jre-tar-gz}}"
+  "{{resource.assets.uris.jre-tar-gz}}",
+  "{{resource.assets.uris.libmesos-bundle-tar-bz2}}"
 ],
 "healthChecks": [
   {
@@ -156,6 +157,7 @@
 ,"EXECUTOR_JRE_LOCATION":"{{resource.assets.uris.jre-tar-gz}}"
 ,"EXECUTOR_LOCATION":"{{resource.assets.uris.executor-zip}}"
 ,"EXECUTOR_CASSANDRA_LOCATION":"{{resource.assets.uris.apache-cassandra-bin-tar-gz}}"
+,"EXECUTOR_LIBMESOS_LOCATION": "{{resource.assets.uris.libmesos-bundle-tar-bz2}}"
 ,"CASSANDRA_LOCATION_DATA_CENTER":"{{service.data_center}}"
 ,"CLUSTER_TASK_CPUS":"{{task.cpus}}"
 ,"CLUSTER_TASK_MEMORY_MB":"{{task.mem}}"

--- a/universe/resource.json
+++ b/universe/resource.json
@@ -4,7 +4,8 @@
       "scheduler-zip":"{{artifact-dir}}/scheduler.zip",
       "executor-zip":"{{artifact-dir}}/executor.zip",
       "jre-tar-gz":"https://downloads.mesosphere.com/cassandra/assets/server-jre-8u74-linux-x64.tar.gz",
-      "apache-cassandra-bin-tar-gz":"https://downloads.mesosphere.com/cassandra/assets/apache-cassandra-3.0.10-bin-dcos.tar.gz"
+      "apache-cassandra-bin-tar-gz":"https://downloads.mesosphere.com/cassandra/assets/apache-cassandra-3.0.10-bin-dcos.tar.gz",
+      "libmesos-bundle-tar-bz2": "http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.bz2"
     }
   },
   "images": {


### PR DESCRIPTION
Bumps the mesos version to 1.0.2 and updates executor to consume a specified mesos binary given a URI.

Confirmed to work on DC/OS 1.7 and 1.8.