### PR TITLE
Bump version to 1.0.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects {
     apply from: "$rootDir/gradle/spock.gradle"
 
     group = 'com.mesosphere.dcos'
-    version = '1.0.18' + (isSnapshot ? '-SNAPSHOT' : '')
+    version = '1.0.21' + (isSnapshot ? '-SNAPSHOT' : '')
 
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'


### PR DESCRIPTION
As 1.0.20 is release, the current master should be the next version.