### PR TITLE
Make the HTTP client timeouts configurable

### DIFF
--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/CassandraSchedulerConfiguration.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/CassandraSchedulerConfiguration.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mesosphere.dcos.cassandra.common.util.JsonUtils;
+import io.dropwizard.client.HttpClientConfiguration;
 import org.apache.mesos.config.ConfigStoreException;
 import org.apache.mesos.config.Configuration;
 import org.apache.mesos.config.SerializationUtils;
@@ -40,7 +41,8 @@ public class CassandraSchedulerConfiguration implements Configuration {
     @JsonProperty("external_dcs") final String externalDcs,
     @JsonProperty("dc_url") final String dcUrl,
     @JsonProperty("phase_strategy") final String phaseStrategy,
-    @JsonProperty("enable_upgrade_sstable_endpoint") final boolean enableUpgradeSSTableEndpoint) {
+    @JsonProperty("enable_upgrade_sstable_endpoint") final boolean enableUpgradeSSTableEndpoint,
+    @JsonProperty("http_client") final HttpClientConfiguration httpClientConfiguration) {
 
     return new CassandraSchedulerConfiguration(
       executorConfig,
@@ -55,7 +57,8 @@ public class CassandraSchedulerConfiguration implements Configuration {
       externalDcs,
       dcUrl,
       phaseStrategy,
-      enableUpgradeSSTableEndpoint
+      enableUpgradeSSTableEndpoint,
+      httpClientConfiguration
     );
   }
 
@@ -85,6 +88,8 @@ public class CassandraSchedulerConfiguration implements Configuration {
   private final String phaseStrategy;
   @JsonIgnore
   private final boolean enableUpgradeSSTableEndpoint;
+  @JsonIgnore
+  private final HttpClientConfiguration httpClientConfiguration;
 
   private CassandraSchedulerConfiguration(
     ExecutorConfig executorConfig,
@@ -98,7 +103,8 @@ public class CassandraSchedulerConfiguration implements Configuration {
     String externalDcs,
     String dcUrl,
     String phaseStrategy,
-    boolean enableUpgradeSSTableEndpoint) {
+    boolean enableUpgradeSSTableEndpoint,
+    HttpClientConfiguration httpClientConfiguration) {
     this.executorConfig = executorConfig;
     this.servers = servers;
     this.seeds = seeds;
@@ -112,6 +118,7 @@ public class CassandraSchedulerConfiguration implements Configuration {
     this.dcUrl = dcUrl;
     this.phaseStrategy = phaseStrategy;
     this.enableUpgradeSSTableEndpoint = enableUpgradeSSTableEndpoint;
+    this.httpClientConfiguration = httpClientConfiguration;
   }
 
   @JsonProperty("executor")
@@ -177,6 +184,9 @@ public class CassandraSchedulerConfiguration implements Configuration {
   @JsonProperty("enable_upgrade_sstable_endpoint")
   public boolean getEnableUpgradeSSTableEndpoint() { return enableUpgradeSSTableEndpoint; }
 
+  @JsonProperty("http_client")
+  public HttpClientConfiguration getHttpClientConfiguration() { return httpClientConfiguration; }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -194,7 +204,8 @@ public class CassandraSchedulerConfiguration implements Configuration {
       Objects.equals(serviceConfig, that.serviceConfig) &&
       Objects.equals(externalDcs, that.externalDcs) &&
       Objects.equals(dcUrl, that.dcUrl) &&
-      Objects.equals(phaseStrategy, that.phaseStrategy);
+      Objects.equals(phaseStrategy, that.phaseStrategy) &&
+      Objects.equals(httpClientConfiguration, that.httpClientConfiguration);
   }
 
   @Override
@@ -212,7 +223,8 @@ public class CassandraSchedulerConfiguration implements Configuration {
       externalDcs,
       dcUrl,
       phaseStrategy,
-      enableUpgradeSSTableEndpoint);
+      enableUpgradeSSTableEndpoint,
+      httpClientConfiguration);
   }
 
   @JsonIgnore

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/MutableSchedulerConfiguration.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/MutableSchedulerConfiguration.java
@@ -3,6 +3,7 @@ package com.mesosphere.dcos.cassandra.common.config;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
+import io.dropwizard.client.HttpClientConfiguration;
 
 import java.util.*;
 
@@ -35,6 +36,7 @@ public class MutableSchedulerConfiguration extends Configuration {
   private String dcUrl;
   private String phaseStrategy;
   private boolean enableUpgradeSSTableEndpoint;
+  private HttpClientConfiguration httpClientConfiguration;
 
   @JsonProperty("mesos")
   public MesosConfig getMesosConfig() {
@@ -191,6 +193,14 @@ public class MutableSchedulerConfiguration extends Configuration {
     this.enableUpgradeSSTableEndpoint = enableUpgradeSSTableEndpoint;
   }
 
+  @JsonProperty("http_client")
+  public HttpClientConfiguration getHttpClientConfiguration() { return httpClientConfiguration; }
+
+  @JsonProperty("http_client")
+  public void setHttpClientConfiguration(HttpClientConfiguration httpClientConfiguration) {
+    this.httpClientConfiguration = httpClientConfiguration;
+  }
+
   @JsonIgnore
   public CassandraSchedulerConfiguration createConfig() {
     return CassandraSchedulerConfiguration.create(
@@ -206,7 +216,8 @@ public class MutableSchedulerConfiguration extends Configuration {
       externalDcs,
       dcUrl,
       phaseStrategy,
-      enableUpgradeSSTableEndpoint
+      enableUpgradeSSTableEndpoint,
+      httpClientConfiguration
     );
   }
 
@@ -228,13 +239,14 @@ public class MutableSchedulerConfiguration extends Configuration {
       Objects.equals(mesosConfig, that.mesosConfig) &&
       Objects.equals(curatorConfig, that.curatorConfig) &&
       Objects.equals(externalDcs, that.externalDcs) &&
-      Objects.equals(dcUrl, that.dcUrl);
+      Objects.equals(dcUrl, that.dcUrl) &&
+      Objects.equals(httpClientConfiguration, that.httpClientConfiguration);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(executorConfig, servers, seeds, placementConstraint, cassandraConfig,
       clusterTaskConfig, apiPort, serviceConfig, mesosConfig, curatorConfig,
-      externalDcSyncMs, externalDcs, dcUrl, enableUpgradeSSTableEndpoint);
+      externalDcSyncMs, externalDcs, dcUrl, enableUpgradeSSTableEndpoint, httpClientConfiguration);
   }
 }

--- a/cassandra-executor/apache-cassandra-2.2.5/conf/cassandra-rackdc.properties
+++ b/cassandra-executor/apache-cassandra-2.2.5/conf/cassandra-rackdc.properties
@@ -1,4 +1,4 @@
 #DCOS got yo Cassandra!
-#Tue Oct 25 10:33:26 PDT 2016
+#Wed Dec 14 15:48:13 PST 2016
 dc=dc1
 rack=rac1

--- a/cassandra-scheduler/src/dist/conf/scheduler.yml
+++ b/cassandra-scheduler/src/dist/conf/scheduler.yml
@@ -192,6 +192,6 @@ logging:
       archivedFileCount: 5
       archivedLogFilenamePattern: ${LOG_FILE:-dcos-cassandra-service.log}.%d
       timeZone: UTC
-httpClient:
+http_client:
   timeout: ${HTTP_CLIENT_TIMEOUT:-500ms}
   connectionTimeout: ${HTTP_CLIENT_CONNECTION_TIMEOUT:-500ms}

--- a/cassandra-scheduler/src/dist/conf/scheduler.yml
+++ b/cassandra-scheduler/src/dist/conf/scheduler.yml
@@ -192,3 +192,6 @@ logging:
       archivedFileCount: 5
       archivedLogFilenamePattern: ${LOG_FILE:-dcos-cassandra-service.log}.%d
       timeZone: UTC
+httpClient:
+  timeout: ${HTTP_CLIENT_TIMEOUT:-500ms}
+  connectionTimeout: ${HTTP_CLIENT_CONNECTION_TIMEOUT:-500ms}

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/SchedulerModule.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/SchedulerModule.java
@@ -12,9 +12,7 @@ import com.mesosphere.dcos.cassandra.common.serialization.Serializer;
 import com.mesosphere.dcos.cassandra.common.tasks.CassandraState;
 import com.mesosphere.dcos.cassandra.common.tasks.CassandraTask;
 import com.mesosphere.dcos.cassandra.scheduler.client.SchedulerClient;
-
 import io.dropwizard.client.HttpClientBuilder;
-import io.dropwizard.client.HttpClientConfiguration;
 import io.dropwizard.setup.Environment;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.retry.RetryForever;
@@ -103,8 +101,8 @@ public class SchedulerModule extends AbstractModule {
                 .annotatedWith(Names.named("ConfiguredEnableUpgradeSSTableEndpoint"))
                 .to(configuration.getEnableUpgradeSSTableEndpoint());
 
-        HttpClientConfiguration httpClient = new HttpClientConfiguration();
-        bind(HttpClient.class).toInstance(new HttpClientBuilder(environment).using(httpClient).build("http-client"));
+        bind(HttpClient.class).toInstance(new HttpClientBuilder(environment).using(
+                configuration.getHttpClientConfiguration()).build("http-client"));
         bind(ExecutorService.class).toInstance(Executors.newCachedThreadPool());
         bind(CuratorFrameworkConfig.class).toInstance(curatorConfig);
         bind(ClusterTaskConfig.class).toInstance(configuration.getClusterTaskConfig());


### PR DESCRIPTION
I have set them to the default values from http://www.dropwizard.io/0.9.1/docs/manual/configuration.html :

```
httpClient:
  timeout: 500ms
  connectionTimeout: 500ms
```
so that this is a No-op for existing clusters.