### PR TITLE
Update libmesos URL from bz2 to gz version

### DIFF
--- a/cassandra-commons/src/test/java/com/mesosphere/dcos/cassandra/common/config/ConfigurationManagerTest.java
+++ b/cassandra-commons/src/test/java/com/mesosphere/dcos/cassandra/common/config/ConfigurationManagerTest.java
@@ -255,7 +255,7 @@ public class ConfigurationManagerTest {
                 URI.create("https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/jre/linux/server-jre-8u74-linux-x64.tar.gz"),
                 URI.create("https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/executor.zip"),
                 URI.create("https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/apache-cassandra-2.2.5-bin.tar.gz"),
-                URI.create("http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.bz2"));
+                URI.create("http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.gz"));
 
         manager.start();
 

--- a/cassandra-commons/src/test/resources/scheduler.yml
+++ b/cassandra-commons/src/test/resources/scheduler.yml
@@ -9,7 +9,7 @@ executor:
   jre_location : ${EXECUTOR_JRE_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/jre/linux/server-jre-8u74-linux-x64.tar.gz'}
   executor_location : ${EXECUTOR_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/executor.zip'}
   cassandra_location : ${EXECUTOR_CASSANDRA_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/apache-cassandra-2.2.5-bin.tar.gz'}
-  libmesos_location: ${EXECUTOR_LIBMESOS_LOCATION:-'http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.bz2'}
+  libmesos_location: ${EXECUTOR_LIBMESOS_LOCATION:-'http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.gz'}
 cluster_task:
   cpus: ${CLUSTER_TASK_CPUS:-1}
   memory_mb: ${CLUSTER_TASK_MEMORY_MB:-256}

--- a/cassandra-executor/src/test/resources/scheduler.yml
+++ b/cassandra-executor/src/test/resources/scheduler.yml
@@ -9,7 +9,7 @@ executor:
   jre_location : ${EXECUTOR_JRE_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/jre/linux/server-jre-8u74-linux-x64.tar.gz'}
   executor_location : ${EXECUTOR_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/executor.zip'}
   cassandra_location : ${EXECUTOR_CASSANDRA_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/apache-cassandra-2.2.5-bin.tar.gz'}
-  libmesos_location: ${EXECUTOR_LIBMESOS_LOCATION:-'http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.bz2'}
+  libmesos_location: ${EXECUTOR_LIBMESOS_LOCATION:-'http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.gz'}
 cluster_task:
   cpus: ${CLUSTER_TASK_CPUS:-1}
   memory_mb: ${CLUSTER_TASK_MEMORY_MB:-256}

--- a/cassandra-scheduler/src/dist/conf/scheduler.yml
+++ b/cassandra-scheduler/src/dist/conf/scheduler.yml
@@ -9,7 +9,7 @@ executor:
   jre_location : ${EXECUTOR_JRE_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/jre/linux/server-jre-8u74-linux-x64.tar.gz'}
   executor_location : ${EXECUTOR_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/executor.zip'}
   cassandra_location : ${EXECUTOR_CASSANDRA_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/apache-cassandra-2.2.5-bin.tar.gz'}
-  libmesos_location: ${EXECUTOR_LIBMESOS_LOCATION:-'http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.bz2'}
+  libmesos_location: ${EXECUTOR_LIBMESOS_LOCATION:-'http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.gz'}
 cluster_task:
   cpus: ${CLUSTER_TASK_CPUS:-1}
   memory_mb: ${CLUSTER_TASK_MEMORY_MB:-256}

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/common/offer/ClusterTaskOfferRequirementProviderTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/common/offer/ClusterTaskOfferRequirementProviderTest.java
@@ -239,13 +239,13 @@ public class ClusterTaskOfferRequirementProviderTest {
             config.getExecutorConfig().getExecutorLocation().toString(),
             cmd.getUrisList().get(0).getValue());
         Assert.assertEquals(
-                config.getExecutorConfig().getLibmesosLocation().toString(),
+                config.getExecutorConfig().getCassandraLocation().toString(),
                 cmd.getUrisList().get(1).getValue());
         Assert.assertEquals(
-            config.getExecutorConfig().getCassandraLocation().toString(),
+            config.getExecutorConfig().getJreLocation().toString(),
             cmd.getUrisList().get(2).getValue());
         Assert.assertEquals(
-            config.getExecutorConfig().getJreLocation().toString(),
+            config.getExecutorConfig().getLibmesosLocation().toString(),
             cmd.getUrisList().get(3).getValue());
     }
 

--- a/cassandra-scheduler/src/test/resources/scheduler.yml
+++ b/cassandra-scheduler/src/test/resources/scheduler.yml
@@ -9,7 +9,7 @@ executor:
   jre_location : ${EXECUTOR_JRE_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/jre/linux/server-jre-8u74-linux-x64.tar.gz'}
   executor_location : ${EXECUTOR_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/executor.zip'}
   cassandra_location : ${EXECUTOR_CASSANDRA_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/apache-cassandra-2.2.5-bin.tar.gz'}
-  libmesos_location: ${EXECUTOR_LIBMESOS_LOCATION:-'http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.bz2'}
+  libmesos_location: ${EXECUTOR_LIBMESOS_LOCATION:-'http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.gz'}
 cluster_task:
   cpus: ${CLUSTER_TASK_CPUS:-1}
   memory_mb: ${CLUSTER_TASK_MEMORY_MB:-256}

--- a/cassandra-scheduler/src/test/resources/update-scheduler.yml
+++ b/cassandra-scheduler/src/test/resources/update-scheduler.yml
@@ -9,7 +9,7 @@ executor:
   jre_location : ${EXECUTOR_JRE_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/jre/linux/server-jre-8u74-linux-x64.tar.gz'}
   executor_location : ${EXECUTOR_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/executor.zip'}
   cassandra_location : ${EXECUTOR_CASSANDRA_LOCATION:-'https://s3-us-west-2.amazonaws.com/cassandra-framework-dev/testing/apache-cassandra-2.2.5-bin-updated.tar.gz'}
-  libmesos_location: ${EXECUTOR_LIBMESOS_LOCATION:-'http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.bz2'}
+  libmesos_location: ${EXECUTOR_LIBMESOS_LOCATION:-'http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.gz'}
 cluster_task:
   cpus: ${CLUSTER_TASK_CPUS:-1}
   memory_mb: ${CLUSTER_TASK_MEMORY_MB:-256}

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -16,7 +16,7 @@
 "uris": [
   "{{resource.assets.uris.scheduler-zip}}",
   "{{resource.assets.uris.jre-tar-gz}}",
-  "{{resource.assets.uris.libmesos-bundle-tar-bz2}}"
+  "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
 ],
 "healthChecks": [
   {
@@ -156,7 +156,7 @@
 ,"EXECUTOR_JRE_LOCATION":"{{resource.assets.uris.jre-tar-gz}}"
 ,"EXECUTOR_LOCATION":"{{resource.assets.uris.executor-zip}}"
 ,"EXECUTOR_CASSANDRA_LOCATION":"{{resource.assets.uris.apache-cassandra-bin-tar-gz}}"
-,"EXECUTOR_LIBMESOS_LOCATION": "{{resource.assets.uris.libmesos-bundle-tar-bz2}}"
+,"EXECUTOR_LIBMESOS_LOCATION": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
 ,"CASSANDRA_LOCATION_DATA_CENTER":"{{service.data_center}}"
 ,"CLUSTER_TASK_CPUS":"{{task.cpus}}"
 ,"CLUSTER_TASK_MEMORY_MB":"{{task.mem}}"

--- a/universe/resource.json
+++ b/universe/resource.json
@@ -5,7 +5,7 @@
       "executor-zip":"{{artifact-dir}}/executor.zip",
       "jre-tar-gz":"https://downloads.mesosphere.com/cassandra/assets/server-jre-8u74-linux-x64.tar.gz",
       "apache-cassandra-bin-tar-gz":"https://downloads.mesosphere.com/cassandra/assets/apache-cassandra-3.0.10-bin-dcos.tar.gz",
-      "libmesos-bundle-tar-bz2": "http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.bz2"
+      "libmesos-bundle-tar-gz": "http://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2.tar.gz"
     }
   },
   "images": {


### PR DESCRIPTION
Use the gz version of libmesos since some systems may not have bzip installed.