### PR TITLE
Perform a hard exit if the framework encounters an exception during i…

### DIFF
--- a/cassandra-executor/apache-cassandra-2.2.5/conf/cassandra-rackdc.properties
+++ b/cassandra-executor/apache-cassandra-2.2.5/conf/cassandra-rackdc.properties
@@ -1,4 +1,4 @@
 #DCOS got yo Cassandra!
-#Fri Dec 16 14:52:56 PST 2016
+#Tue Jan 03 14:20:21 PST 2017
 dc=dc1
 rack=rac1

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/Main.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/Main.java
@@ -20,9 +20,15 @@ import org.slf4j.LoggerFactory;
 public class Main extends Application<MutableSchedulerConfiguration> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
+  private static final int EXIT_CODE = 7;
 
   public static void main(String[] args) throws Exception {
-    new Main().run(args);
+    try {
+      new Main().run(args);
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while trying to run main: exiting framework process with code: " + EXIT_CODE);
+      System.exit(EXIT_CODE);
+    }
   }
 
   public Main() {

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/Main.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/Main.java
@@ -14,20 +14,20 @@ import io.dropwizard.java8.Java8Bundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.text.StrSubstitutor;
+import org.apache.mesos.scheduler.SchedulerErrorCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Main extends Application<MutableSchedulerConfiguration> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
-  private static final int EXIT_CODE = 7;
 
   public static void main(String[] args) throws Exception {
     try {
       new Main().run(args);
     } catch (Exception e) {
-      LOGGER.error("Caught exception while trying to run main: exiting framework process with code: " + EXIT_CODE);
-      System.exit(EXIT_CODE);
+      LOGGER.error("Caught exception while trying to run main: exiting framework process");
+      System.exit(SchedulerErrorCode.ERROR.ordinal());
     }
   }
 


### PR DESCRIPTION
…nitialization

For example, we encounter this situation when the HTTP port that the framework listens to is already in use.