### PR TITLE
Avoid exposing NPE to users

### DIFF
--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/ClusterTaskRunner.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/ClusterTaskRunner.java
@@ -30,7 +30,7 @@ class ClusterTaskRunner<R extends ClusterTaskRequest, C extends ClusterTaskConte
     Response start(R request) {
         LOGGER.info("Processing start {} request: {}", taskName, request);
         try {
-            if (!request.isValid()) {
+            if (request == null || !request.isValid()) {
                 return Response.status(Response.Status.BAD_REQUEST).build();
             } else if (!manager.isInProgress()) {
                 manager.start(request);


### PR DESCRIPTION
This happens when there is no parameter when hitting the endpoint. A minor improvement though.

```
  ! java.lang.NullPointerException: null
  ! at com.mesosphere.dcos.cassandra.scheduler.resources.ClusterTaskRunner.start(ClusterTaskRunner.java:33) ~[cassandra-scheduler.jar:na]
  ! at com.mesosphere.dcos.cassandra.scheduler.resources.RepairResource.start(RepairResource.java:29) [cassandra-scheduler.jar:na]
  ! at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_112]
  ! at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_112]
  ! at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_112]
  ! at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_112]
  ! at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory$1.invoke(ResourceMethodInvocationHandlerFactory.java:81) [jersey-server-2.23.2.jar:na]
  ! at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:144) [jersey-server-2.23.2.jar:na]
  ! at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:161) [jersey-server-2.23.2.jar:na]
  ! at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:160) [jersey-server-2.23.2.jar:na]
  ! at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:99) [jersey-server-2.23.2.jar:na]
  ! at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:389) [jersey-server-2.23.2.jar:na]
  ! at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:347) [jersey-server-2.23.2.jar:na]
  ! at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:102) [jersey-server-2.23.2.jar:na]
```