### PR TITLE
Reset the replace IP only when a Cassandra Daemon transitions to NORM…

### DIFF
--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraDaemonTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraDaemonTask.java
@@ -125,9 +125,11 @@ public class CassandraDaemonTask extends CassandraTask {
     }
 
     private static CassandraConfig updateConfig(
-        final Protos.TaskState state,
+        final CassandraMode mode,
         final CassandraConfig config) {
-        if (Protos.TaskState.TASK_RUNNING.equals(state)) {
+        // If the Cassandra daemon has transitioned to the NORMAL mode, remove the replaceIp so that the next
+        // time Cassandra starts, it does not have the startup argument -Dcassandra.replace_address=<replaceIp>.
+        if (CassandraMode.NORMAL.equals(mode)) {
             return config.mutable().setReplaceIp("").build();
         } else {
             return config;
@@ -216,7 +218,7 @@ public class CassandraDaemonTask extends CassandraTask {
                     .setData(getData().updateDaemon(
                         daemonStatus.getState(),
                         daemonStatus.getMode(),
-                        updateConfig(daemonStatus.getState(), getConfig())
+                        updateConfig(daemonStatus.getMode(), getConfig())
                     ).getBytes()).build()
             );
         }


### PR DESCRIPTION
…AL and not when the Mesos task transitions to RUNNING.

We need to do this because when we replace a node, the new Daemon can start up fine and the Mesos task transitions to RUNNING, but then fail while bootstrapping. In this case, the restarted daemon does not have replaceIp set. So, we need to reset the replaceIp only when the Cassandra daemon transitions to the NORMAL mode.