### PR TITLE
Send reviveOffers() only if the scheduler had suppressed them before

### DIFF
--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/CassandraScheduler.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/CassandraScheduler.java
@@ -417,9 +417,12 @@ public class CassandraScheduler implements Scheduler, Observer {
                 "Scheduler has operations to perform." :
                 "Scheduler has no operations to perform.");
         if (hasOperations) {
-            LOGGER.info("Reviving offers.");
-            driver.reviveOffers();
-            cassandraState.setSuppressed(false);
+            // Revive offers only if they were previously suppressed.
+            if (cassandraState.isSuppressed()) {
+                LOGGER.info("Reviving offers.");
+                driver.reviveOffers();
+                cassandraState.setSuppressed(false);
+            }
         } else {
             LOGGER.info("Suppressing offers.");
             driver.suppressOffers();


### PR DESCRIPTION
We are currently running ~50 frameworks. The current version of the framework unnecessarily sends a lot of `reviveOffers()` calls to the Mesos master causing backlogs in the allocator queue since a reviveOffer is pretty expensive. 

This PR changes the behavior so that reviveOffers is called only if the offers were suppressed earlier.