### PR TITLE
Remove timestamp from cassandra-rackdc.properties file to avoid merge…

### DIFF
--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/Location.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/Location.java
@@ -22,10 +22,9 @@ import com.mesosphere.dcos.cassandra.common.util.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.nio.file.Path;
-import java.util.Properties;
 
 /**
  * Location represents the rack and data center for a node in a Cassandra
@@ -117,35 +116,17 @@ public class Location {
     }
 
     /**
-     * Gets a properties object containing the properties parsed by a
-     * Cassandra daemon to determine its rack and data center.
-     *
-     * @return A Properties object indicating the rack and data center
-     * contained in the location.
-     */
-    public Properties toProperties() {
-
-        Properties properties = new Properties();
-        properties.setProperty("rack", rack);
-        properties.setProperty("dc", dataCenter);
-        return properties;
-    }
-
-    /**
      * Writes the Location as a Properties file.
      *
      * @param path The Path indicating where the Location will be written.
      * @throws IOException If the Location can not be written to path.
      */
     public void writeProperties(Path path) throws IOException {
-
         logger.info("Writing properties to path: " + path.toAbsolutePath());
-        FileOutputStream stream = new FileOutputStream(path.toFile());
-        try {
-            toProperties().store(stream, "DCOS got yo Cassandra!");
-        } finally {
-            stream.close();
-        }
+        PrintWriter writer = new PrintWriter(path.toString(), "UTF-8");
+        writer.println("dc=" + dataCenter);
+        writer.println("rack=" + rack);
+        writer.close();
     }
 
     /**

--- a/cassandra-executor/apache-cassandra-2.2.5/conf/cassandra-rackdc.properties
+++ b/cassandra-executor/apache-cassandra-2.2.5/conf/cassandra-rackdc.properties
@@ -1,4 +1,2 @@
-#DCOS got yo Cassandra!
-#Fri Dec 16 14:52:56 PST 2016
 dc=dc1
 rack=rac1


### PR DESCRIPTION
… conflicts.

This file has been causing unnecessary merge conflicts for every PR. 

I couldn't see a way to avoid printing the timestamp in Properties#store function (http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b14/java/util/Properties.java#824) and there was no clear way out: http://stackoverflow.com/questions/6184335/properties-store-suppress-timestamp-comment

So I have re-written the file in a different and much simpler way.