### PR TITLE
Fix node replacement error by creating fresh task in recovery scheduler

### DIFF
--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/CassandraConfig.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/CassandraConfig.java
@@ -74,7 +74,7 @@ public class CassandraConfig {
          *
          * @param config The CassandraConfig that will be copied.
          */
-        private Builder(CassandraConfig config) {
+        public Builder(CassandraConfig config) {
 
             this.version = config.version;
             this.cpus = config.cpus;

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/ConfigurationManager.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/config/ConfigurationManager.java
@@ -55,6 +55,19 @@ public class ConfigurationManager implements Managed {
             cassandraConfig);
     }
 
+    public CassandraDaemonTask createDaemon(String frameworkId,
+                                            String name,
+                                            String role,
+                                            String principal,
+                                            String configName,
+                                            CassandraConfig cassandraConfig) throws ConfigStoreException {
+        return cassandraDaemonTaskFactory.create(
+                name,
+                configName,
+                createExecutor(frameworkId, name + "_executor", role, principal),
+                cassandraConfig);
+    }
+
     public CassandraDaemonTask moveDaemon(
             CassandraDaemonTask daemonTask,
             String frameworkId,

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/CassandraRecoveryScheduler.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/CassandraRecoveryScheduler.java
@@ -4,6 +4,7 @@ import com.mesosphere.dcos.cassandra.common.offer.PersistentOfferRequirementProv
 import com.mesosphere.dcos.cassandra.common.persistence.PersistenceException;
 import com.mesosphere.dcos.cassandra.common.tasks.CassandraDaemonTask;
 import com.mesosphere.dcos.cassandra.common.tasks.CassandraState;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.mesos.Protos;
 import org.apache.mesos.SchedulerDriver;
 import org.apache.mesos.config.ConfigStoreException;
@@ -56,12 +57,13 @@ public class CassandraRecoveryScheduler extends ChainedObserver {
                 terminated = cassandraState.replaceDaemon(terminated);
 
                 Optional<OfferRequirement> offerReq;
-                if (terminated.getConfig().getReplaceIp().isEmpty()) {
+                String replaceIp = terminated.getConfig().getReplaceIp();
+                if (StringUtils.isEmpty(replaceIp)) {
                     offerReq = offerRequirementProvider.getReplacementOfferRequirement(
                             cassandraState.getOrCreateContainer(terminated.getName()));
                 } else {
                     offerReq = offerRequirementProvider.getNewOfferRequirement(
-                            cassandraState.createCassandraContainer(terminated));
+                            cassandraState.createCassandraContainer(terminated.getName(), replaceIp));
                 }
 
                 if (offerReq.isPresent()) {


### PR DESCRIPTION
Node replacement was failing due to a corrupted TaskInfo, missing a Persistence definition, making its way into the recovery pipeline. This seems to happen at a dependable place -- the creation of an offer requirement for the new replacement node based on the old node's `CassandraDaemonTask` in `CassandraState` -- so this change avoids using the old task definition and instead manually stitches in the replacement IP. (We tossed around the idea of removing this, but I think that's outside of the scope of this PR for now.)