### PR TITLE
[CASSANDRA-529] Revert "Support upgrades from corrupted enum state in 1.0.19 (#346)"

### DIFF
--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraDaemonTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraDaemonTask.java
@@ -210,7 +210,7 @@ public class CassandraDaemonTask extends CassandraTask {
 
     @Override
     public CassandraDaemonTask update(CassandraTaskStatus status) {
-        if (status.getTaskType() == TYPE.CASSANDRA_DAEMON &&
+        if (status.getType() == TYPE.CASSANDRA_DAEMON &&
             status.getId().equals(getId())) {
             CassandraDaemonStatus daemonStatus = (CassandraDaemonStatus) status;
             return new CassandraDaemonTask(

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraData.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraData.java
@@ -9,8 +9,6 @@ import com.mesosphere.dcos.cassandra.common.tasks.cleanup.CleanupContext;
 import com.mesosphere.dcos.cassandra.common.tasks.repair.RepairContext;
 import com.mesosphere.dcos.cassandra.common.tasks.upgradesstable.UpgradeSSTableContext;
 import org.apache.mesos.Protos;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
@@ -19,10 +17,9 @@ import java.util.List;
  * CassandraData encapsulates command task and status data
  */
 public class CassandraData {
-    private final Logger LOGGER = LoggerFactory.getLogger(CassandraData.class);
 
-    public static final CassandraData parse(final ByteString bytes, final boolean isTemplateTask) {
-        return new CassandraData(bytes, isTemplateTask);
+    public static final CassandraData parse(final ByteString bytes) {
+        return new CassandraData(bytes);
     }
 
     public static final CassandraData createTemplateData() {
@@ -221,17 +218,9 @@ public class CassandraData {
 
     private final CassandraProtos.CassandraData data;
 
-    private CassandraData(final ByteString bytes, final boolean isTemplateTask) {
+    private CassandraData(final ByteString bytes) {
         try {
-            CassandraProtos.CassandraData data = CassandraProtos.CassandraData.parseFrom(bytes);
-            CassandraProtos.CassandraData.Builder builder = CassandraProtos.CassandraData.newBuilder(data);
-            if (isTemplateTask && builder.getType() != CassandraTask.TYPE.TEMPLATE.ordinal()) {
-                LOGGER.info("Parsing CassandraData from corrupted CassandraTask.TYPE Enum.  I've detected that the " +
-                        "task for this data should be of type CassandraTask.TYPE.TEMPLATE, but actually has type {}." +
-                        "  Forcing type CassandraTask.TYPE.TEMPLATE.", CassandraTask.TYPE.values()[builder.getType()]);
-                builder.setType(CassandraTask.TYPE.TEMPLATE.ordinal());
-            }
-            this.data = builder.build();
+            this.data = CassandraProtos.CassandraData.parseFrom(bytes);
         } catch (InvalidProtocolBufferException e) {
             throw new IllegalArgumentException("Invalid ByteString passed to " +
                 "CassandraData", e);

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraState.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraState.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Inject;
 import com.google.protobuf.TextFormat;
-import com.mesosphere.dcos.cassandra.common.CassandraProtos;
 import com.mesosphere.dcos.cassandra.common.config.CassandraSchedulerConfiguration;
 import com.mesosphere.dcos.cassandra.common.config.ClusterTaskConfig;
 import com.mesosphere.dcos.cassandra.common.config.ConfigurationManager;
@@ -74,22 +73,7 @@ public class CassandraState extends SchedulerState implements Managed {
 
                 for (Protos.TaskInfo taskInfo : taskInfos) {
                     try {
-                        Protos.TaskInfo unpackedInfo = TaskUtils.unpackTaskInfo(taskInfo);
-                        final CassandraTask cassandraTask = CassandraTask.parse(unpackedInfo);
-
-                        final boolean isTemplateTask = CassandraTemplateTask.isTemplateTaskName(taskInfo.getName());
-                        final CassandraProtos.CassandraData oldCassandraData =
-                                CassandraProtos.CassandraData.parseFrom(unpackedInfo.getData());
-                        if (isTemplateTask && oldCassandraData.getType() != CassandraTask.TYPE.TEMPLATE.ordinal()) {
-                            CassandraData data = CassandraData.parse(unpackedInfo.getData(), isTemplateTask);
-                            Protos.TaskInfo updatedUnpackedInfo =
-                                    Protos.TaskInfo.newBuilder(unpackedInfo).setData(data.getBytes()).build();
-
-                            LOGGER.info("Writing updated TaskInfo for task {} to StateStore to fix corrupted " +
-                                    "CassandraTask.TYPE Enum.", taskInfo.getName());
-                            getStateStore().storeTasks(Arrays.asList(TaskUtils.packTaskInfo(updatedUnpackedInfo)));
-                        }
-
+                        final CassandraTask cassandraTask = CassandraTask.parse(TaskUtils.unpackTaskInfo(taskInfo));
                         LOGGER.debug("Loaded task: {}, type: {}, hostname: {}",
                                 cassandraTask.getName(), cassandraTask.getType().name(), cassandraTask.getHostname());
                         builder.put(cassandraTask.getName(), cassandraTask);
@@ -624,22 +608,7 @@ public class CassandraState extends SchedulerState implements Managed {
                     }
 
                     if (status.hasData()) {
-                        final boolean isTemplateTask = CassandraTemplateTask.isTemplateTaskName(
-                                cassandraTask.getName());
-                        CassandraTaskStatus cassandraTaskStatus = CassandraTaskStatus.parse(status, isTemplateTask);
-                        cassandraTask = cassandraTask.update(cassandraTaskStatus);
-
-                        final CassandraProtos.CassandraData oldCassandraData =
-                                CassandraProtos.CassandraData.parseFrom(status.getData());
-                        if (isTemplateTask && oldCassandraData.getType() != CassandraTask.TYPE.TEMPLATE.ordinal()) {
-                            CassandraData data = CassandraData.parse(status.getData(), isTemplateTask);
-                            Protos.TaskStatus updatedStatus =
-                                    Protos.TaskStatus.newBuilder(status).setData(data.getBytes()).build();
-
-                            LOGGER.info("Writing updated TaskStatus for task {} to StateStore to fix corrupted " +
-                                    "CassandraTask.TYPE Enum.", cassandraTask.getName());
-                            getStateStore().storeStatus(updatedStatus);
-                        }
+                        cassandraTask = cassandraTask.update(CassandraTaskStatus.parse(status));
                     } else {
                         cassandraTask = cassandraTask.update(status.getState());
                     }

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraTask.java
@@ -133,8 +133,7 @@ public abstract class CassandraTask {
      * @throws IOException If a CassandraTask can not be parsed from info.
      */
     public static CassandraTask parse(final Protos.TaskInfo info) {
-        final boolean isTemplateTask = CassandraTemplateTask.isTemplateTaskName(info.getName());
-        CassandraData data = CassandraData.parse(info.getData(), isTemplateTask);
+        CassandraData data = CassandraData.parse(info.getData());
         switch (data.getType()) {
             case CASSANDRA_DAEMON:
                 return CassandraDaemonTask.parse(info);
@@ -173,10 +172,10 @@ public abstract class CassandraTask {
         return TaskUtils.toTaskId(name);
     }
 
-    protected final Protos.TaskInfo info;
+    private final Protos.TaskInfo info;
 
     protected CassandraData getData() {
-        return CassandraData.parse(info.getData(), false);
+        return CassandraData.parse(info.getData());
     }
 
     protected Protos.TaskInfo.Builder getBuilder() {

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraTaskStatus.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraTaskStatus.java
@@ -20,7 +20,6 @@ import com.mesosphere.dcos.cassandra.common.tasks.backup.*;
 import com.mesosphere.dcos.cassandra.common.tasks.cleanup.CleanupStatus;
 import com.mesosphere.dcos.cassandra.common.tasks.repair.RepairStatus;
 import com.mesosphere.dcos.cassandra.common.tasks.upgradesstable.UpgradeSSTableStatus;
-import org.apache.cassandra.thrift.Cassandra;
 import org.apache.mesos.Protos;
 
 import java.io.IOException;
@@ -90,9 +89,9 @@ public abstract class CassandraTaskStatus {
         return Protos.TaskState.TASK_FINISHED.equals(state);
     }
 
-    public static CassandraTaskStatus parse(final Protos.TaskStatus status, final boolean isTemplateTask)
+    public static CassandraTaskStatus parse(final Protos.TaskStatus status)
         throws IOException {
-        CassandraData data = CassandraData.parse(status.getData(), isTemplateTask);
+        CassandraData data = CassandraData.parse(status.getData());
         switch (data.getType()) {
             case CASSANDRA_DAEMON:
                 return CassandraDaemonStatus.create(status);
@@ -127,7 +126,7 @@ public abstract class CassandraTaskStatus {
     }
 
     protected CassandraData getData() {
-        return CassandraData.parse(status.getData(), this instanceof TemplateTaskStatus);
+        return CassandraData.parse(status.getData());
     }
 
     /**
@@ -170,11 +169,11 @@ public abstract class CassandraTaskStatus {
     }
 
     /**
-     * Gets the task TYPE.
+     * Gets the TYPE.
      *
      * @return The TYPE of task associated with the status.
      */
-    public CassandraTask.TYPE getTaskType() {
+    public CassandraTask.TYPE getType() {
         return getData().getType();
     }
 

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraTemplateTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraTemplateTask.java
@@ -5,23 +5,16 @@ import com.mesosphere.dcos.cassandra.common.tasks.backup.TemplateTaskStatus;
 import org.apache.mesos.Protos;
 import org.apache.mesos.offer.ResourceUtils;
 import org.apache.mesos.offer.TaskUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Optional;
 
 
 public class CassandraTemplateTask extends CassandraTask  {
-
     private static final String CLUSTER_TASK_TEMPLATE_SUFFIX = "-task-template";
 
     public static String toTemplateTaskName(String daemonTaskName) {
         return daemonTaskName + CLUSTER_TASK_TEMPLATE_SUFFIX;
-    }
-
-    public static boolean isTemplateTaskName(String taskName) {
-        return taskName.endsWith(CLUSTER_TASK_TEMPLATE_SUFFIX);
     }
 
     protected static Protos.SlaveID EMPTY_SLAVE_ID = Protos.SlaveID
@@ -92,12 +85,6 @@ public class CassandraTemplateTask extends CassandraTask  {
                 .setState(state)
                 .build());
     }
-
-    @Override
-    protected CassandraData getData() {
-        return CassandraData.parse(info.getData(), true);
-    }
-
 
     private static Protos.Resource getCpusResource(
             String role,

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/BackupSchemaTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/BackupSchemaTask.java
@@ -97,7 +97,7 @@ public class BackupSchemaTask extends CassandraTask{
 
     @Override
     public BackupSchemaTask update(CassandraTaskStatus status) {
-        if (status.getTaskType() == TYPE.BACKUP_SCHEMA &&
+        if (status.getType() == TYPE.BACKUP_SCHEMA &&
                 getId().equalsIgnoreCase(status.getId())) {
             return update(status.getState());
         }

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/BackupSnapshotTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/BackupSnapshotTask.java
@@ -111,7 +111,7 @@ public class BackupSnapshotTask extends CassandraTask {
 
     @Override
     public BackupSnapshotTask update(CassandraTaskStatus status) {
-        if (status.getTaskType() == TYPE.BACKUP_SNAPSHOT &&
+        if (status.getType() == TYPE.BACKUP_SNAPSHOT &&
             getId().equalsIgnoreCase(status.getId())) {
             return update(status.getState());
         }

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/BackupUploadTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/BackupUploadTask.java
@@ -111,7 +111,7 @@ public class BackupUploadTask extends CassandraTask {
 
     @Override
     public BackupUploadTask update(CassandraTaskStatus status) {
-        if (status.getTaskType() == TYPE.BACKUP_UPLOAD &&
+        if (status.getType() == TYPE.BACKUP_UPLOAD &&
             getId().equalsIgnoreCase(status.getId())) {
             return update(status.getState());
         }

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/DownloadSnapshotTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/DownloadSnapshotTask.java
@@ -106,7 +106,7 @@ public class DownloadSnapshotTask extends CassandraTask {
 
     @Override
     public DownloadSnapshotTask update(CassandraTaskStatus status) {
-        if (status.getTaskType() == TYPE.SNAPSHOT_DOWNLOAD &&
+        if (status.getType() == TYPE.SNAPSHOT_DOWNLOAD &&
             getId().equalsIgnoreCase(status.getId())) {
             return update(status.getState());
         }

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/RestoreSchemaTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/RestoreSchemaTask.java
@@ -93,7 +93,7 @@ public class RestoreSchemaTask extends CassandraTask {
 
     @Override
     public RestoreSchemaTask update(CassandraTaskStatus status) {
-        if (status.getTaskType() == CassandraTask.TYPE.SCHEMA_RESTORE &&
+        if (status.getType() == CassandraTask.TYPE.SCHEMA_RESTORE &&
                 getId().equalsIgnoreCase(status.getId())) {
             return update(status.getState());
         }

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/RestoreSnapshotTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/RestoreSnapshotTask.java
@@ -106,7 +106,7 @@ public class RestoreSnapshotTask extends CassandraTask {
 
     @Override
     public RestoreSnapshotTask update(CassandraTaskStatus status) {
-        if (status.getTaskType() == TYPE.SNAPSHOT_RESTORE &&
+        if (status.getType() == TYPE.SNAPSHOT_RESTORE &&
             getId().equalsIgnoreCase(status.getId())) {
             return update(status.getState());
         }

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/TemplateTaskStatus.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/backup/TemplateTaskStatus.java
@@ -1,9 +1,11 @@
 package com.mesosphere.dcos.cassandra.common.tasks.backup;
 
-import com.mesosphere.dcos.cassandra.common.tasks.CassandraData;
 import com.mesosphere.dcos.cassandra.common.tasks.CassandraTaskStatus;
 import org.apache.mesos.Protos;
 
+/**
+ * Created by gabriel on 6/9/16.
+ */
 public class TemplateTaskStatus extends CassandraTaskStatus {
 
     public static TemplateTaskStatus create(final Protos.TaskStatus status) {

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/cleanup/CleanupTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/cleanup/CleanupTask.java
@@ -109,7 +109,7 @@ public class CleanupTask extends CassandraTask {
 
     @Override
     public CleanupTask update(CassandraTaskStatus status) {
-        if (status.getTaskType() == TYPE.CLEANUP &&
+        if (status.getType() == TYPE.CLEANUP &&
             getId().equalsIgnoreCase(status.getId())) {
             return update(status.getState());
         }

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/repair/RepairTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/repair/RepairTask.java
@@ -104,7 +104,7 @@ public class RepairTask extends CassandraTask {
 
     @Override
     public RepairTask update(CassandraTaskStatus status) {
-        if (status.getTaskType() == TYPE.REPAIR &&
+        if (status.getType() == TYPE.REPAIR &&
             getId().equalsIgnoreCase(status.getId())) {
             return update(status.getState());
         }

--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/upgradesstable/UpgradeSSTableTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/upgradesstable/UpgradeSSTableTask.java
@@ -109,7 +109,7 @@ public class UpgradeSSTableTask extends CassandraTask {
 
     @Override
     public UpgradeSSTableTask update(CassandraTaskStatus status) {
-        if (status.getTaskType() == TYPE.UPGRADESSTABLE &&
+        if (status.getType() == TYPE.UPGRADESSTABLE &&
             getId().equalsIgnoreCase(status.getId())) {
             return update(status.getState());
         }

--- a/cassandra-executor/apache-cassandra-2.2.5/conf/cassandra-rackdc.properties
+++ b/cassandra-executor/apache-cassandra-2.2.5/conf/cassandra-rackdc.properties
@@ -1,2 +1,4 @@
+#DCOS got yo Cassandra!
+#Tue Jan 17 16:20:57 PST 2017
 dc=dc1
 rack=rac1

--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonStep.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/plan/CassandraDaemonStep.java
@@ -40,7 +40,7 @@ public class CassandraDaemonStep extends DefaultStep {
         }
 
         if (status.get().hasData()) {
-            final CassandraData data = CassandraData.parse(status.get().getData(), false);
+            final CassandraData data = CassandraData.parse(status.get().getData());
             final CassandraMode mode = data.getMode();
             String hostName = data.getHostname();
             final boolean isModeNormal = CassandraMode.NORMAL.equals(mode);
@@ -165,7 +165,7 @@ public class CassandraDaemonStep extends DefaultStep {
                 return;
             }
             if (status.hasData()) {
-                final CassandraData cassandraData = CassandraData.parse(status.getData(), false);
+                final CassandraData cassandraData = CassandraData.parse(status.getData());
                 mode = cassandraData.getMode();
                 LOGGER.info("{} Step: {} received status: {} with mode: {}",
                         getStatus(), getName(), TextFormat.shortDebugString(status), cassandraData.getMode());

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/tasks/CassandraStateTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/tasks/CassandraStateTest.java
@@ -164,7 +164,7 @@ public class CassandraStateTest {
         Assert.assertEquals(testHostName, originalDaemonTask.getHostname());
 
         CassandraDaemonTask movedDaemonTask = cassandraState.moveDaemon(originalDaemonTask);
-        CassandraData movedData = CassandraData.parse(movedDaemonTask.getTaskInfo().getData(), false);
+        CassandraData movedData = CassandraData.parse(movedDaemonTask.getTaskInfo().getData());
         String movedReplaceIp = movedData.getConfig().getReplaceIp();
         Assert.assertEquals(originalDaemonTask.getHostname(), movedReplaceIp);
     }


### PR DESCRIPTION
This reverts commit 1534bf149d32b90d7eef6fbb39a5ac2be2dd4a2d.

Reverting this code, since it was only relevant in 1.0.20