### PR TITLE
Fix build: port of #338 from dcos-kafka-service

### DIFF
--- a/integration/tests/command.py
+++ b/integration/tests/command.py
@@ -129,13 +129,14 @@ def spin(fn, success_predicate, wait_time=WAIT_TIME_IN_SECONDS, *args, **kwargs)
     return result
 
 
-def install(additional_options = {}, package_version = None):
+def install(additional_options = {}, package_version = None, wait = True):
     merged_options = _nested_dict_merge(DEFAULT_OPTIONS_DICT, additional_options)
     print('Installing {} with options: {} {}'.format(PACKAGE_NAME, merged_options, package_version))
     shakedown.install_package_and_wait(
         PACKAGE_NAME,
         package_version,
-        options_json=merged_options)
+        options_json=merged_options,
+        waiit_for_completion=wait)
 
 
 def uninstall():

--- a/integration/tests/command.py
+++ b/integration/tests/command.py
@@ -136,7 +136,7 @@ def install(additional_options = {}, package_version = None, wait = True):
         PACKAGE_NAME,
         package_version,
         options_json=merged_options,
-        waiit_for_completion=wait)
+        wait_for_completion=wait)
 
 
 def uninstall():

--- a/integration/tests/test_marathon_constraint.py
+++ b/integration/tests/test_marathon_constraint.py
@@ -44,7 +44,9 @@ def allow_incomplete_plan(status_code):
 
 @pytest.mark.sanity
 def test_marathon_rack_not_found():
-    install(additional_options = {'service':{'placement_constraint':'rack_id:LIKE:rack-foo-.*'}})
+    # install without waiting, since the install should never succeed and a timeout would result in an
+    # assertion failure
+    install(additional_options = {'service':{'placement_constraint':'rack_id:LIKE:rack-foo-.*'}}, wait=False)
     try:
         check_health(wait_time=60) # long enough for /plan to work and for a node to have been IN_PROGRESS
         assert False, "Should have failed healthcheck"


### PR DESCRIPTION
Workaround for behavior change in shakedown's package install command