### PR TITLE
Try removing a 'version' field in gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ allprojects {
     apply from: "$rootDir/gradle/spock.gradle"
 
     group = 'com.mesosphere.dcos'
-    version = '1.0.18' + (isSnapshot ? '-SNAPSHOT' : '')
 
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'


### PR DESCRIPTION
There's no way anyone's going to remember this thing. Does removing it break anything?