### PR TITLE
fixing an issue that causes backup to fail if there exists folders for dropped tables 

### DIFF
--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/backup/AzureStorageDriver.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/backup/AzureStorageDriver.java
@@ -78,12 +78,13 @@ public class AzureStorageDriver implements BackupStorageDriver {
       for (File cfDir : keyspaceDir.listFiles()) {
         logger.info("Entering column family: {}", cfDir.getName());
         File snapshotDir = new File(cfDir, "snapshots");
-        if (!StorageUtil.isValidBackupDir(keyspaceDir, cfDir, snapshotDir)) {
+        File backupDir = new File(snapshotDir, backupName);
+        if (!StorageUtil.isValidBackupDir(keyspaceDir, cfDir, snapshotDir, backupDir)) {
           logger.info("Skipping directory: {}", snapshotDir.getAbsolutePath());
           continue;
         }
         logger.info(
-          "Valid backup directories. Keyspace: {} | ColumnFamily: {} | Snapshot: {} | BackupName: {}",
+          "Valid backup directories. KeyspaceDir: {} | ColumnFamilyDir: {} | SnapshotDir: {} | BackupName: {}",
           keyspaceDir.getAbsolutePath(), cfDir.getAbsolutePath(),
           snapshotDir.getAbsolutePath(), backupName);
 

--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/backup/S3StorageDriver.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/backup/S3StorageDriver.java
@@ -154,15 +154,16 @@ public class S3StorageDriver implements BackupStorageDriver {
                 }
                 LOGGER.info("Entering keyspace: {}", keyspaceDir.getName());
                 for (File cfDir : getColumnFamilyDir(keyspaceDir)) {
-                    LOGGER.info("Entering column family: {}", cfDir.getName());
+                    LOGGER.info("Entering column family dir: {}", cfDir.getName());
                     File snapshotDir = new File(cfDir, "snapshots");
-                    if (!StorageUtil.isValidBackupDir(keyspaceDir, cfDir, snapshotDir)) {
+                    File backupDir = new File(snapshotDir, backupName);
+                    if (!StorageUtil.isValidBackupDir(keyspaceDir, cfDir, snapshotDir, backupDir)) {
                         LOGGER.info("Skipping directory: {}",
                                 snapshotDir.getAbsolutePath());
                         continue;
                     }
                     LOGGER.info(
-                            "Valid backup directories. Keyspace: {} | ColumnFamily: {} | Snapshot: {} | BackupName: {}",
+                            "Valid backup directories. KeyspaceDir: {} | ColumnFamilyDir: {} | SnapshotDir: {} | BackupName: {}",
                             keyspaceDir.getAbsolutePath(), cfDir.getAbsolutePath(),
                             snapshotDir.getAbsolutePath(), backupName);
 

--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/backup/StorageUtil.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/backup/StorageUtil.java
@@ -27,7 +27,7 @@ public final class StorageUtil {
    * Filters unwanted keyspaces and column families
    */
   static boolean isValidBackupDir(File ksDir, File cfDir, File ssDir, File bkDir) {
-    if (!ssDir.exists() || !ssDir.isDirectory() || !bkDir.exists()) {
+    if (!ssDir.exists() || !ssDir.isDirectory() || !bkDir.exists() || !bkDir.isDirectory()) {
       return false;
     }
 

--- a/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/backup/StorageUtil.java
+++ b/cassandra-executor/src/main/java/com/mesosphere/dcos/cassandra/executor/backup/StorageUtil.java
@@ -26,8 +26,8 @@ public final class StorageUtil {
   /**
    * Filters unwanted keyspaces and column families
    */
-  static boolean isValidBackupDir(File ksDir, File cfDir, File bkDir) {
-    if (!bkDir.isDirectory() && !bkDir.exists()) {
+  static boolean isValidBackupDir(File ksDir, File cfDir, File ssDir, File bkDir) {
+    if (!ssDir.exists() || !ssDir.isDirectory() || !bkDir.exists()) {
       return false;
     }
 


### PR DESCRIPTION
fixing the issue which allows the logic to enter Column Family folder that belongs to a dropped table when iterating snapshots to upload.