### PR TITLE
Revert node replacement behavior so that the framework does not pass …

### DIFF
--- a/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraDaemonTask.java
+++ b/cassandra-commons/src/main/java/com/mesosphere/dcos/cassandra/common/tasks/CassandraDaemonTask.java
@@ -125,11 +125,9 @@ public class CassandraDaemonTask extends CassandraTask {
     }
 
     private static CassandraConfig updateConfig(
-        final CassandraMode mode,
+        final Protos.TaskState state,
         final CassandraConfig config) {
-        // If the Cassandra daemon has transitioned to the NORMAL mode, remove the replaceIp so that the next
-        // time Cassandra starts, it does not have the startup argument -Dcassandra.replace_address=<replaceIp>.
-        if (CassandraMode.NORMAL.equals(mode)) {
+        if (Protos.TaskState.TASK_RUNNING.equals(state)) {
             return config.mutable().setReplaceIp("").build();
         } else {
             return config;
@@ -218,7 +216,7 @@ public class CassandraDaemonTask extends CassandraTask {
                     .setData(getData().updateDaemon(
                         daemonStatus.getState(),
                         daemonStatus.getMode(),
-                        updateConfig(daemonStatus.getMode(), getConfig())
+                        updateConfig(daemonStatus.getState(), getConfig())
                     ).getBytes()).build()
             );
         }


### PR DESCRIPTION
…-Dcassandra.replace_address if a task fails and restarts.

Summary: Reverts https://github.com/mesosphere/dcos-cassandra-service/pull/362.

After testing with some deployments, we have found out that this causes problems when multiple Cassandra tasks fail at the same time. A node cannot bootstrap if any node is in the DN state, so we need to remove the node using `nodetool removenode <hostid>`. But then this change passes -D replace_address every time it starts the task but we have already removed the node and Cassandra crash loops.