### PR TITLE
Various fixes for install

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -297,13 +297,13 @@ The service configuration object contains properties that MUST be specified duri
     <tr>
       <td>mem</td>
       <td>integer</td>
-      <td>The amount of memory, in MB, allocated for the DC/OS Apache Cassandra Service scheduler. This MUST be larger than the allocated heap. 2 Gb is a good choice.</td>
+      <td>The amount of memory, in MB, allocated for the DC/OS Apache Cassandra Service scheduler. This MUST be larger than the allocated heap. 2 GB is a good choice.</td>
     </tr>
 
     <tr>
       <td>heap</td>
       <td>integer</td>
-      <td>The amount of heap, in MB, allocated for the DC/OS Apache Cassandra Service scheduler. 1 Gb is a minimum for production installations.</td>
+      <td>The amount of heap, in MB, allocated for the DC/OS Apache Cassandra Service scheduler. 1 GB is a minimum for production installations.</td>
     </tr>
 
     <tr>

--- a/docs/install-and-customize.md
+++ b/docs/install-and-customize.md
@@ -5,14 +5,21 @@ feature_maturity: preview
 enterprise: 'no'
 ---
 
-# About installing Cassandra on Enterprise DC/OS
+Cassandra for DC/OS is available in the Universe and can be installed by using either the web interface or the DC/OS CLI.
 
- In Enterprise DC/OS `strict` [security mode](https://docs.mesosphere.com/1.9/administration/installing/custom/configuration-parameters/#security), Cassandra requires a service account. In `permissive`, a service account is optional. Only someone with `superuser` permission can create the service account. Refer to [Provisioning Cassandra](https://docs.mesosphere.com/1.9/administration/id-and-access-mgt/service-auth/cass-auth/#give-perms) for instructions.
+## Prerequisites
+
+- Depending on your security mode in Enterprise DC/OS, you may need to provision a service account before installing Cassandra. Only someone with `superuser` permission can create the service account.
+    - `strict` [security mode](https://docs.mesosphere.com/1.9/administration/installing/custom/configuration-parameters/#security) requires a service account.  
+    - `permissive` security mode a service account is optional. 
+    - `disabled` security mode does not require a service account.
+- Minimum three agent nodes with eight GB of memory and ten GB of disk available on each agent.
+- Ports 7000, 7001, 7199, 9042, and 9160 are available.
 
 # Default Installation
-Prior to installing a default cluster, ensure that your DC/OS cluster has at least 3 agent nodes with 8 Gb of memory and 10 Gb of disk available on each agent. Also, ensure that ports 7000, 7001, 7199, 9042, and 9160 are available.
+The default installation may not be sufficient for a production deployment, but all cluster operations will work. If you are planning a production deployment with three replicas of each value and local quorum consistency for read and write operations (a very common use case), this configuration is sufficient for development and testing purposes and it may be scaled to a production deployment.
 
-To start a default cluster, run the following command on the DC/OS CLI. The default installation may not be sufficient for a production deployment, but all cluster operations will work. If you are planning a production deployment with 3 replicas of each value and local quorum consistency for read and write operations (a very common use case), this configuration is sufficient for development and testing purposes and it may be scaled to a production deployment.
+To start a default cluster, run the following command on the DC/OS CLI. 
 
 ```
 $ dcos package install cassandra
@@ -82,7 +89,7 @@ To start a minimal cluster with a single node, create a JSON options file that c
     }
 }
 ```
-This will create a single node cluster with 2 Gb of memory and 4Gb of disk. Note that you will need an additional 512 Mb for the DC/OS Apache Cassandra Service executor and 128 Mb for clusters tasks. The DC/OS Apache Cassandra Service scheduler needs 512 MB to run, but it does not need to be deployed on the same host as the node.
+This will create a single node cluster with 2 GB of memory and 4Gb of disk. Note that you will need an additional 512 Mb for the DC/OS Apache Cassandra Service executor and 128 Mb for clusters tasks. The DC/OS Apache Cassandra Service scheduler needs 512 MB to run, but it does not need to be deployed on the same host as the node.
 
 # Multiple Cassandra Cluster Installation
 

--- a/docs/install-and-customize.md
+++ b/docs/install-and-customize.md
@@ -9,7 +9,7 @@ Cassandra for DC/OS is available in the Universe and can be installed by using e
 
 ## Prerequisites
 
-- Depending on your security mode in Enterprise DC/OS, you may need to provision a service account before installing Cassandra. Only someone with `superuser` permission can create the service account.
+- Depending on your security mode in Enterprise DC/OS, you may [need to provision a service account](/1.9/administration/id-and-access-mgt/service-auth/cass-auth/#give-perms) before installing Cassandra. Only someone with `superuser` permission can create the service account.
     - `strict` [security mode](https://docs.mesosphere.com/1.9/administration/installing/custom/configuration-parameters/#security) requires a service account.  
     - `permissive` security mode a service account is optional. 
     - `disabled` security mode does not require a service account.

--- a/docs/install-and-customize.md
+++ b/docs/install-and-customize.md
@@ -14,7 +14,7 @@ Cassandra for DC/OS is available in the Universe and can be installed by using e
     - `permissive` security mode a service account is optional. 
     - `disabled` security mode does not require a service account.
 - Minimum three agent nodes with eight GB of memory and ten GB of disk available on each agent.
-- Ports 7000, 7001, 7199, 9042, and 9160 are available.
+- Ports 7000, 7001, 7199, 9042, and 9160 must be available.
 
 # Default Installation
 The default installation may not be sufficient for a production deployment, but all cluster operations will work. If you are planning a production deployment with three replicas of each value and local quorum consistency for read and write operations (a very common use case), this configuration is sufficient for development and testing purposes and it may be scaled to a production deployment.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -36,7 +36,7 @@ enterprise: 'no'
 
     Now that you are inside your DC/OS cluster, you can connect to your Cassandra cluster directly.
 
-1. Launch a docker container containing `cqlsh` to connect to your cassandra cluster:
+1. Launch a Docker container containing `cqlsh` to connect to your cassandra cluster:
 
         core@ip-10-0-6-153 ~ $ docker run -ti cassandra:3.0.7 cqlsh --cqlversion="3.4.0" node-0.cassandra.mesos
         cqlsh>


### PR DESCRIPTION
- Created prerequisites heading and made Enterprise security requirements more prominent.
- Changed all cases of `Gb` (gigabits) to `GB` (gigabytes)
- Rearranged text in default installation for better readability.