### PR TITLE
Spot fix for actual test failure; probably the whole file needs this …

### DIFF
--- a/integration/tests/test_sanity.py
+++ b/integration/tests/test_sanity.py
@@ -250,12 +250,13 @@ def test_node_is_replaced():
 
     # Check that we've created a new task with a new id, waiting until a new one comes up.
     def get_status():
-        return get_first(
-            get_dcos_command('task --json'), lambda t: t['name'] == 'node-0'
-        )['id']
+        first_node0 = get_first(get_dcos_command('task --json'), lambda t: t['name'] == 'node-0')
+        if first_node0:
+            return first_node0['id']
+        return None
 
     def success_predicate(task_id):
-        return task_id != replaced_node_task_id, 'Task ID for replaced node did not change'
+        return task_id and (task_id != replaced_node_task_id), 'Task ID for replaced node did not change'
 
     spin(get_status, success_predicate)
 


### PR DESCRIPTION
…change, but that's another JIRA.

Probably this whole test suite needs similar rework.  However, the change definitely fixes a failure that actually happened, and the tests run clean and correct with the change https://jenkins.mesosphere.com/service/jenkins/view/Infinity/job/cassandra/job/1-build-linux/785/  

So for a marginal improvement I think it's worth it.   I'll file a followup jira to review the rest, and maybe if those tests aren't slated for deletion I'll do it too.