### PR TITLE
Fixed 'nodes status' endpoint return code, when node not found

### DIFF
--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/TasksResource.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/TasksResource.java
@@ -78,7 +78,7 @@ public class TasksResource {
             Optional.ofNullable(state.getDaemons().get(name));
         if (!taskOption.isPresent()) {
             response.resume(
-                Response.status(Response.Status.NOT_FOUND));
+                Response.status(Response.Status.NOT_FOUND).build());
         } else {
             CassandraDaemonTask task = taskOption.get();
             client.status(task.getHostname(), task.getExecutor().getApiPort()


### PR DESCRIPTION
Fixed 'nodes status' endpoint return code 400 -> 404 when node not found. The code was already trying to return a NOT_FOUND status, but was missing a "build()".