### PR TITLE
Crash the scheduler if the scheduler driver receives an error

### DIFF
--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/CassandraScheduler.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/CassandraScheduler.java
@@ -341,6 +341,8 @@ public class CassandraScheduler implements Scheduler, Observer {
     @Override
     public void error(SchedulerDriver driver, String message) {
         LOGGER.error("Scheduler driver error: {}", message);
+        // At this point the scheduler driver is already aborted, so there is no point staying alive.
+        throw new RuntimeException("Scheduler driver has been aborted because of error: " + message);
     }
 
     private List<Protos.Offer> filterAcceptedOffers(List<Protos.Offer> offers,

--- a/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/CassandraSchedulerTest.java
+++ b/cassandra-scheduler/src/test/java/com/mesosphere/dcos/cassandra/scheduler/CassandraSchedulerTest.java
@@ -322,6 +322,13 @@ public class CassandraSchedulerTest {
         update();
     }
 
+    @Test(expected = RuntimeException.class)
+    // Test that the scheduler throws a RuntimeException if the scheduler driver sends an error.
+    public void testSchedulerDriverError() throws Exception {
+        install();
+        scheduler.error(driver, "scheduler driver error");
+    }
+
     private void update() {
         scheduler.registered(driver, frameworkId, Protos.MasterInfo.getDefaultInstance());
         runReconcile(driver);


### PR DESCRIPTION
This can happen for example, if the Mesos master sends an authentication timeout if it is overloaded.