### PR TITLE
Reverted "Fixed 'nodes status' endpoint return code 400 -> 404 when node not found. (#428)"

### DIFF
--- a/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/TasksResource.java
+++ b/cassandra-scheduler/src/main/java/com/mesosphere/dcos/cassandra/scheduler/resources/TasksResource.java
@@ -78,7 +78,7 @@ public class TasksResource {
             Optional.ofNullable(state.getDaemons().get(name));
         if (!taskOption.isPresent()) {
             response.resume(
-                Response.status(Response.Status.NOT_FOUND).build());
+                Response.status(Response.Status.NOT_FOUND));
         } else {
             CassandraDaemonTask task = taskOption.get();
             client.status(task.getHostname(), task.getExecutor().getApiPort()


### PR DESCRIPTION
Revert "Fixed 'nodes status' endpoint return code 400 -> 404 when node not found. (#428)"

This reverts commit 73bf7405badfbee16d7ca29f7fd41d0e83104120.